### PR TITLE
[BE] 태그 DTO 리팩터링

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/SelectiveOptionTagDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/SelectiveOptionTagDto.java
@@ -6,6 +6,7 @@ import com.softeer2nd.ohmycarset.domain.selective.RequiredOption;
 import lombok.Getter;
 
 import java.beans.ConstructorProperties;
+import java.util.List;
 
 @Getter
 public class SelectiveOptionTagDto {
@@ -13,43 +14,48 @@ public class SelectiveOptionTagDto {
 
     private final Long optionId;
     private final String optionName;
-    private final String tagName;
-    private final Double percentage;
+    private final Double purchaseRate;
+    private final Double similarity;
+    private final List<TagDto> tags;
 
-    @ConstructorProperties({"optionId", "optionName", "tagName", "percentage"})
-    public SelectiveOptionTagDto(Long optionId, String optionName, String tagName, Double percentage) {
+    @ConstructorProperties({"optionId", "optionName", "purchaseRate", "similarity", "tags"})
+    public SelectiveOptionTagDto(Long optionId, String optionName, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
         this.optionId = optionId;
         this.optionName = optionName;
-        this.tagName = tagName;
-        this.percentage = percentage;
+        this.purchaseRate = purchaseRate;
+        this.similarity = similarity;
+        this.tags = tagDtoList;
     }
 
-    public SelectiveOptionTagDto(RequiredOption requiredOption, Double percentage) {
+    public SelectiveOptionTagDto(RequiredOption requiredOption, Double purchaseRate) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
-        this.tagName = PURCHASE_PERCENTAGE;
-        this.percentage = percentage;
+        this.purchaseRate = purchaseRate;
+        this.similarity = null;
+        this.tags = null;
     }
 
-    public SelectiveOptionTagDto(RequiredOption requiredOption, Tag tag, Double percentage) {
+    public SelectiveOptionTagDto(RequiredOption requiredOption, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
-        this.tagName = tag.getName();
-        this.percentage = percentage;
+        this.purchaseRate = purchaseRate;
+        this.similarity = similarity;
+        this.tags = tagDtoList;
     }
 
-
-    public SelectiveOptionTagDto(OptionPackage requiredOption, Double percentage) {
+    public SelectiveOptionTagDto(OptionPackage requiredOption, Double purchaseRate) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
-        this.tagName = PURCHASE_PERCENTAGE;
-        this.percentage = percentage;
+        this.purchaseRate = purchaseRate;
+        this.similarity = null;
+        this.tags = null;
     }
 
-    public SelectiveOptionTagDto(OptionPackage requiredOption, Tag tag, Double percentage) {
+    public SelectiveOptionTagDto(OptionPackage requiredOption, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
-        this.tagName = tag.getName();
-        this.percentage = percentage;
+        this.purchaseRate = purchaseRate;
+        this.similarity = similarity;
+        this.tags = tagDtoList;
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/SelectiveOptionTagDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/SelectiveOptionTagDto.java
@@ -10,20 +10,16 @@ import java.util.List;
 
 @Getter
 public class SelectiveOptionTagDto {
-    private static final String PURCHASE_PERCENTAGE = "구매비율";
-
     private final Long optionId;
     private final String optionName;
     private final Double purchaseRate;
-    private final Double similarity;
     private final List<TagDto> tags;
 
-    @ConstructorProperties({"optionId", "optionName", "purchaseRate", "similarity", "tags"})
-    public SelectiveOptionTagDto(Long optionId, String optionName, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
+    @ConstructorProperties({"optionId", "optionName", "purchaseRate", "tags"})
+    public SelectiveOptionTagDto(Long optionId, String optionName, Double purchaseRate, List<TagDto> tagDtoList) {
         this.optionId = optionId;
         this.optionName = optionName;
         this.purchaseRate = purchaseRate;
-        this.similarity = similarity;
         this.tags = tagDtoList;
     }
 
@@ -31,15 +27,13 @@ public class SelectiveOptionTagDto {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
         this.purchaseRate = purchaseRate;
-        this.similarity = null;
         this.tags = null;
     }
 
-    public SelectiveOptionTagDto(RequiredOption requiredOption, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
+    public SelectiveOptionTagDto(RequiredOption requiredOption, Double purchaseRate, List<TagDto> tagDtoList) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
         this.purchaseRate = purchaseRate;
-        this.similarity = similarity;
         this.tags = tagDtoList;
     }
 
@@ -47,15 +41,13 @@ public class SelectiveOptionTagDto {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
         this.purchaseRate = purchaseRate;
-        this.similarity = null;
         this.tags = null;
     }
 
-    public SelectiveOptionTagDto(OptionPackage requiredOption, Double purchaseRate, Double similarity, List<TagDto> tagDtoList) {
+    public SelectiveOptionTagDto(OptionPackage requiredOption, Double purchaseRate, List<TagDto> tagDtoList) {
         this.optionId = requiredOption.getId();
         this.optionName = requiredOption.getName();
         this.purchaseRate = purchaseRate;
-        this.similarity = similarity;
         this.tags = tagDtoList;
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/TagDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/SelectiveOptionTagDto/TagDto.java
@@ -1,0 +1,26 @@
+package com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto;
+
+import com.softeer2nd.ohmycarset.domain.Tag;
+import lombok.Getter;
+
+import java.beans.ConstructorProperties;
+
+@Getter
+public class TagDto {
+    private final Long id;
+    private final String name;
+    private final Double percentage;
+
+    @ConstructorProperties({"id", "name", "percentage"})
+    public TagDto(Long id, String name, Double percentage) {
+        this.id = id;
+        this.name = name;
+        this.percentage = percentage;
+    }
+
+    public TagDto(Tag tag, Double percentage) {
+        this.id = tag.getId();
+        this.name = tag.getName();
+        this.percentage = percentage;
+    }
+}

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/UserInfoDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/UserInfoDto.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 @Getter
 public class UserInfoDto {
-    private final List<String> tagNameList;
     public final Integer age;
     public final Character gender;
     public final String tag1;
@@ -21,7 +20,5 @@ public class UserInfoDto {
         this.tag1 = tag1;
         this.tag2 = tag2;
         this.tag3 = tag3;
-
-        this.tagNameList = new ArrayList<>(Arrays.asList(tag1, tag2, tag3));
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/TagRepository.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/TagRepository.java
@@ -12,5 +12,5 @@ public interface TagRepository {
 
     Optional<Tag> findByName(String name);
 
-    List<Tag> findAllByOptionNameAndOptionId(String optionName, Long powerTrainOptionId);
+    List<Tag> findAllByOptionNameAndOptionId(String optionName, Long optionId);
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
@@ -3,6 +3,7 @@ package com.softeer2nd.ohmycarset.service;
 import com.softeer2nd.ohmycarset.domain.Tag;
 import com.softeer2nd.ohmycarset.domain.selective.RequiredOption;
 import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.SelectiveOptionTagDto;
+import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.TagDto;
 import com.softeer2nd.ohmycarset.dto.UserInfoDto;
 import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
 import com.softeer2nd.ohmycarset.repository.SelectiveOptionRepository;
@@ -67,6 +68,7 @@ public class TagService {
     }
 
     public List<SelectiveOptionTagDto> getKeywordTagRequiredOption(UserInfoDto userInfoDto, String optionName) {
+        // 입력된 태그명에 해당하는 Tag 객체들로 변환합니다.
         List<Tag> tagList = new ArrayList<>();
         List<String> tagNameList = userInfoDto.getTagNameList();
         for (String tagName : tagNameList) {
@@ -76,11 +78,21 @@ public class TagService {
         // 본 카테고리의 모든 옵션의 목록을 가져옵니다.
         List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByOptionName(optionName);
 
-        // 모든 태그들을 담을 목록을 만듭니다.
+        // 모든 부가 정보들을 담을 목록을 만듭니다.
         List<SelectiveOptionTagDto> optionTagDtoList = new ArrayList<>();
-        // 각 옵션에 대해 태그 목록을 구합니다.
+
+        // 각 옵션에 대해 구매비율, 유사도 및 태그 목록을 구합니다.
+        Long totalPurchaseCount = purchaseHistoryRepository.count(); // 구매비율 연산용
         for (RequiredOption option : optionList) {
-            List<SelectiveOptionTagDto> tagDtoList = new ArrayList<>();
+            // 구매비율
+            Long optionPurchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, option.getId());
+            Double purchaseRate = (double) optionPurchaseCount / totalPurchaseCount * 100;
+
+            // TODO 유사도 연산 로직
+            Double similarity = 0.;
+
+            // 사용자 선택 태그 기반 태그 유사도
+            List<TagDto> tagDtoList = new ArrayList<>();
 
             // 유저가 선택한 태그와 옵션에 정의된 태그 중 겹치는 태그만 연산합니다.
             List<Tag> intersectionTagList = new ArrayList<>();
@@ -105,20 +117,21 @@ public class TagService {
                 Double selectionPercentage = (double) intersectionPurchaseCount / purchaseCount * 100;
 
                 // 태그 목록에 추가합니다.
-                tagDtoList.add(new SelectiveOptionTagDto(option, tag, selectionPercentage));
+                tagDtoList.add(new TagDto(tag, selectionPercentage));
             }
 
             // 높은 유사도순으로 재정렬합니다.
             tagDtoList.sort((t0, t1) -> Double.compare(t1.getPercentage(), t0.getPercentage()));
 
             // 목록에 담습니다.
-            optionTagDtoList.addAll(tagDtoList);
+            optionTagDtoList.add(new SelectiveOptionTagDto(option, purchaseRate, similarity, tagDtoList));
         }
 
         return optionTagDtoList;
     }
 
     public List<SelectiveOptionTagDto> getKeywordTagOptionPackage(UserInfoDto userInfoDto, String packageName) {
+        // 입력된 태그명에 해당하는 Tag 객체들로 변환합니다.
         List<Tag> tagList = new ArrayList<>();
         List<String> tagNameList = userInfoDto.getTagNameList();
         for (String tagName : tagNameList) {
@@ -128,11 +141,21 @@ public class TagService {
         // 본 카테고리의 모든 옵션의 목록을 가져옵니다.
         List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByOptionName(packageName);
 
-        // 모든 태그들을 담을 목록을 만듭니다.
+        // 모든 부가 정보들을 담을 목록을 만듭니다.
         List<SelectiveOptionTagDto> optionTagDtoList = new ArrayList<>();
-        // 각 옵션에 대해 태그 목록을 구합니다.
+
+        // 각 옵션에 대해 구매비율, 유사도 및 태그 목록을 구합니다.
+        Long totalPurchaseCount = purchaseHistoryRepository.count(); // 구매비율 연산용
         for (RequiredOption option : optionList) {
-            List<SelectiveOptionTagDto> tagDtoList = new ArrayList<>();
+            // 구매비율
+            Long optionPurchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, option.getId());
+            Double purchaseRate = (double) optionPurchaseCount / totalPurchaseCount * 100;
+
+            // TODO 유사도 연산 로직
+            Double similarity = 0.;
+
+            // 사용자 선택 태그 기반 태그 유사도
+            List<TagDto> tagDtoList = new ArrayList<>();
 
             // 유저가 선택한 태그와 옵션에 정의된 태그 중 겹치는 태그만 연산합니다.
             List<Tag> intersectionTagList = new ArrayList<>();
@@ -157,14 +180,14 @@ public class TagService {
                 Double selectionPercentage = (double) intersectionPurchaseCount / purchaseCount * 100;
 
                 // 태그 목록에 추가합니다.
-                tagDtoList.add(new SelectiveOptionTagDto(option, tag, selectionPercentage));
+                tagDtoList.add(new TagDto(tag, selectionPercentage));
             }
 
             // 높은 유사도순으로 재정렬합니다.
             tagDtoList.sort((t0, t1) -> Double.compare(t1.getPercentage(), t0.getPercentage()));
 
             // 목록에 담습니다.
-            optionTagDtoList.addAll(tagDtoList);
+            optionTagDtoList.add(new SelectiveOptionTagDto(option, purchaseRate, similarity, tagDtoList));
         }
 
         return optionTagDtoList;

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
@@ -1,6 +1,7 @@
 package com.softeer2nd.ohmycarset.service;
 
 import com.softeer2nd.ohmycarset.domain.Tag;
+import com.softeer2nd.ohmycarset.domain.selective.OptionPackage;
 import com.softeer2nd.ohmycarset.domain.selective.RequiredOption;
 import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.SelectiveOptionTagDto;
 import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.TagDto;
@@ -47,21 +48,21 @@ public class TagService {
 
     public List<SelectiveOptionTagDto> getPurchaseTagByPackageName(String packageName) {
         // 각 카운트 조회
-        Map<RequiredOption, Long> purchaseCountMap = new HashMap<>();
+        Map<OptionPackage, Long> purchaseCountMap = new HashMap<>();
 
-        List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByOptionName(packageName);
-        for(RequiredOption option: optionList) {
-            Long purchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, option.getId());
-            purchaseCountMap.put(option, purchaseCount);
+        List<OptionPackage> optionPackageList = selectiveOptionRepository.findAllPackageByPackageName(packageName);
+        for(OptionPackage optionPackage: optionPackageList) {
+            Long purchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, optionPackage.getId());
+            purchaseCountMap.put(optionPackage, purchaseCount);
         }
 
         // 확률 계산 및 태그로 전송
         List<SelectiveOptionTagDto> selectiveOptionTagDtoList = new ArrayList<>();
 
         Long purchaseCountSum = purchaseCountMap.values().stream().mapToLong(Long::longValue).sum();
-        for(RequiredOption option: optionList) {
-            Double purchasePercentage = (double) purchaseCountMap.get(option) / purchaseCountSum * 100;
-            selectiveOptionTagDtoList.add(new SelectiveOptionTagDto(option, purchasePercentage));
+        for(OptionPackage optionPackage: optionPackageList) {
+            Double purchasePercentage = (double) purchaseCountMap.get(optionPackage) / purchaseCountSum * 100;
+            selectiveOptionTagDtoList.add(new SelectiveOptionTagDto(optionPackage, purchasePercentage));
         }
 
         return selectiveOptionTagDtoList;
@@ -138,17 +139,17 @@ public class TagService {
             tagList.add(tagRepository.findByName(tagName).orElse(null));
         }
 
-        // 본 카테고리의 모든 옵션의 목록을 가져옵니다.
-        List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByOptionName(packageName);
+        // 본 카테고리의 모든 옵션 패키지의 목록을 가져옵니다.
+        List<OptionPackage> optionPackageList = selectiveOptionRepository.findAllPackageByPackageName(packageName);
 
         // 모든 부가 정보들을 담을 목록을 만듭니다.
         List<SelectiveOptionTagDto> optionTagDtoList = new ArrayList<>();
 
         // 각 옵션에 대해 구매비율, 유사도 및 태그 목록을 구합니다.
         Long totalPurchaseCount = purchaseHistoryRepository.count(); // 구매비율 연산용
-        for (RequiredOption option : optionList) {
+        for (OptionPackage optionPackage : optionPackageList) {
             // 구매비율
-            Long optionPurchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, option.getId());
+            Long optionPurchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, optionPackage.getId());
             Double purchaseRate = (double) optionPurchaseCount / totalPurchaseCount * 100;
 
             // TODO 유사도 연산 로직
@@ -159,7 +160,7 @@ public class TagService {
 
             // 유저가 선택한 태그와 옵션에 정의된 태그 중 겹치는 태그만 연산합니다.
             List<Tag> intersectionTagList = new ArrayList<>();
-            List<Tag> optionTagList = tagRepository.findAllByOptionNameAndOptionId(packageName, option.getId());
+            List<Tag> optionTagList = tagRepository.findAllByOptionNameAndOptionId(packageName, optionPackage.getId());
             for (Tag tag : tagList) {
                 for (Tag optionTag : optionTagList) {
                     if (Objects.equals(tag.getId(), optionTag.getId())) {
@@ -174,7 +175,7 @@ public class TagService {
                 Long purchaseCount = purchaseHistoryRepository.countByTagId(tag.getId());
 
                 // 해당 태그를 선택하고, 해당 옵션을 구매한 내역 수를 받아옵니다.
-                Long intersectionPurchaseCount = purchaseHistoryRepository.countByTagIdAndPackageNameAndOptionId(tag.getId(), packageName, option.getId());
+                Long intersectionPurchaseCount = purchaseHistoryRepository.countByTagIdAndPackageNameAndOptionId(tag.getId(), packageName, optionPackage.getId());
 
                 // 선택 비율을 연산합니다.
                 Double selectionPercentage = (double) intersectionPurchaseCount / purchaseCount * 100;
@@ -187,7 +188,7 @@ public class TagService {
             tagDtoList.sort((t0, t1) -> Double.compare(t1.getPercentage(), t0.getPercentage()));
 
             // 목록에 담습니다.
-            optionTagDtoList.add(new SelectiveOptionTagDto(option, purchaseRate, similarity, tagDtoList));
+            optionTagDtoList.add(new SelectiveOptionTagDto(optionPackage, purchaseRate, similarity, tagDtoList));
         }
 
         return optionTagDtoList;

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
@@ -89,8 +89,8 @@ public class TagService {
             Long optionPurchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, option.getId());
             Double purchaseRate = (double) optionPurchaseCount / totalPurchaseCount * 100;
 
-            // TODO 유사도 연산 로직
-            Double similarity = 0.;
+            // TODO 유사도 연산 로직(purchaseRate 갱신)
+            // purchaseRate = 80;
 
             // 사용자 선택 태그 기반 태그 유사도
             List<TagDto> tagDtoList = new ArrayList<>();
@@ -125,7 +125,7 @@ public class TagService {
             tagDtoList.sort((t0, t1) -> Double.compare(t1.getPercentage(), t0.getPercentage()));
 
             // 목록에 담습니다.
-            optionTagDtoList.add(new SelectiveOptionTagDto(option, purchaseRate, similarity, tagDtoList));
+            optionTagDtoList.add(new SelectiveOptionTagDto(option, purchaseRate, tagDtoList));
         }
 
         return optionTagDtoList;
@@ -152,8 +152,8 @@ public class TagService {
             Long optionPurchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, optionPackage.getId());
             Double purchaseRate = (double) optionPurchaseCount / totalPurchaseCount * 100;
 
-            // TODO 유사도 연산 로직
-            Double similarity = 0.;
+            // TODO 유사도 연산 로직(purchaseRate 갱신)
+            // purchaseRate = 80;
 
             // 사용자 선택 태그 기반 태그 유사도
             List<TagDto> tagDtoList = new ArrayList<>();
@@ -188,7 +188,7 @@ public class TagService {
             tagDtoList.sort((t0, t1) -> Double.compare(t1.getPercentage(), t0.getPercentage()));
 
             // 목록에 담습니다.
-            optionTagDtoList.add(new SelectiveOptionTagDto(optionPackage, purchaseRate, similarity, tagDtoList));
+            optionTagDtoList.add(new SelectiveOptionTagDto(optionPackage, purchaseRate, tagDtoList));
         }
 
         return optionTagDtoList;

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/TagService.java
@@ -70,7 +70,7 @@ public class TagService {
     public List<SelectiveOptionTagDto> getKeywordTagRequiredOption(UserInfoDto userInfoDto, String optionName) {
         // 입력된 태그명에 해당하는 Tag 객체들로 변환합니다.
         List<Tag> tagList = new ArrayList<>();
-        List<String> tagNameList = userInfoDto.getTagNameList();
+        List<String> tagNameList = new ArrayList<>(Arrays.asList(userInfoDto.getTag1(), userInfoDto.getTag2(), userInfoDto.getTag3()));
         for (String tagName : tagNameList) {
             tagList.add(tagRepository.findByName(tagName).orElse(null));
         }
@@ -133,7 +133,7 @@ public class TagService {
     public List<SelectiveOptionTagDto> getKeywordTagOptionPackage(UserInfoDto userInfoDto, String packageName) {
         // 입력된 태그명에 해당하는 Tag 객체들로 변환합니다.
         List<Tag> tagList = new ArrayList<>();
-        List<String> tagNameList = userInfoDto.getTagNameList();
+        List<String> tagNameList = new ArrayList<>(Arrays.asList(userInfoDto.getTag1(), userInfoDto.getTag2(), userInfoDto.getTag3()));
         for (String tagName : tagNameList) {
             tagList.add(tagRepository.findByName(tagName).orElse(null));
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가(리팩터링)
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/refactor/tag_refactor -> dev

### 변경 사항
1. 태그 엔드포인트의 DTO를 재설계하였습니다. 이제 SelectiveOptionTagDto는 purchaseRate(구매비율), similarity(유사도), tags(태그/퍼센트 객체 리스트, List<TagDto>)를 갖습니다.
2. swagger문서에서 post 요청을 날릴 때, tagNameList를 통해 DTO가 tag1,tag2,tag3를 리스트로 변환하는 책임을 가졌던 구조에서 서비스가 해당 책임을 수행하는 구조로 변경하였습니다.
3. 옵션패키지를 처리하는 과정에서 OptionPackage가 아닌 RequiredOption으로 객체를 생성했던 논리적 결함을 수정하였습니다.
4. findAllByOptionNameAndOptionId에서 optionId 인자명이 powertrainOptionId였기에, 현 구조에 맞춰 optionId로 수정하였습니다.
