### PR TITLE
[BE] 셀프 모드 선택옵션 정렬 후 전달

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -26,46 +26,52 @@ public class SelectiveOptionService {
     }
 
     public List<RequiredOptionDto> getAllOptionByName(String optionName) {
-        List<RequiredOptionDto> requiredOptionDtoList = new ArrayList<>();
-
+        // 해당 카테고리의 모든 옵션 목록을 받아옵니다.
         List<RequiredOption> requiredOptionList = selectiveOptionRepository.findAllOptionByOptionName(optionName);
+
+        // 각 옵션에 대해 구매 건수를 조회합니다.
+        Map<RequiredOption, Long> purchaseCountMap = new HashMap<>();
+        for(RequiredOption eColorOption: requiredOptionList) {
+            Long purchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, eColorOption.getId());
+            purchaseCountMap.put(eColorOption, purchaseCount);
+        }
+
+        // 내림차순으로 정렬합니다.
+        List<RequiredOption> sortedKeys = purchaseCountMap.entrySet().stream()
+                .sorted(Map.Entry.<RequiredOption, Long>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
 
         // 외장 색상 옵션인 경우 특수 처리 필요
         if(optionName.equals("exterior_color")) {
-            // 각 색상 옵션에 대해 구매 건수를 조회합니다.
-            Map<RequiredOption, Long> purchaseCountMap = new HashMap<>();
-            for(RequiredOption eColorOption: requiredOptionList) {
-                Long purchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, eColorOption.getId());
-                purchaseCountMap.put(eColorOption, purchaseCount);
-            }
-            // 내림차순으로 정렬합니다.
-            List<RequiredOption> sortedKeys = purchaseCountMap.entrySet().stream()
-                    .sorted(Map.Entry.<RequiredOption, Long>comparingByValue().reversed())
-                    .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
-            //각 순위에 따라 다르게 Feedback을 설정해줍니다.
-            for(int rank = 1; rank < sortedKeys.size() + 1; rank++) {
-                RequiredOption option = sortedKeys.get(rank - 1);
-                if(rank == 1) {
-                    option.setMainFeedback(String.format("%s 색상은 가장 많이 판매됐어요!", option.getName()));
-                    option.setSubFeedback("가장 인기있는 색상을 원하신다면, 탁월한 선택입니다.");
-                }
-                if(2 <= rank && rank <= 3) {
-                    option.setMainFeedback(String.format("%s 색상은 인기가 많아요!", option.getName()));
-                    option.setSubFeedback("인기있는 색상을 원하신다면, 탁월한 선택입니다.");
-                }
-                if(4 <= rank && rank <= 6) {
-                    option.setMainFeedback(String.format("%s 색상은 희소성이 있어요!", option.getName()));
-                    option.setSubFeedback("독특한 색상을 원하신다면, 탁월한 선택입니다.");
-                }
-            }
+            handleExteriorColorOption(sortedKeys);
         }
 
-        for (RequiredOption requiredOption : requiredOptionList) {
+        List<RequiredOptionDto> requiredOptionDtoList = new ArrayList<>();
+        for (RequiredOption requiredOption : sortedKeys) {
             requiredOptionDtoList.add(new RequiredOptionDto(requiredOption));
         }
 
         return requiredOptionDtoList;
+    }
+
+    private void handleExteriorColorOption(List<RequiredOption> optionList) {
+        //각 순위에 따라 다르게 Feedback을 설정해줍니다.
+        for(int rank = 1; rank < optionList.size() + 1; rank++) {
+            RequiredOption option = optionList.get(rank - 1);
+            if(rank == 1) {
+                option.setMainFeedback(String.format("%s 색상은 가장 많이 판매됐어요!", option.getName()));
+                option.setSubFeedback("가장 인기있는 색상을 원하신다면, 탁월한 선택입니다.");
+            }
+            if(2 <= rank && rank <= 3) {
+                option.setMainFeedback(String.format("%s 색상은 인기가 많아요!", option.getName()));
+                option.setSubFeedback("인기있는 색상을 원하신다면, 탁월한 선택입니다.");
+            }
+            if(4 <= rank && rank <= 6) {
+                option.setMainFeedback(String.format("%s 색상은 희소성이 있어요!", option.getName()));
+                option.setSubFeedback("독특한 색상을 원하신다면, 탁월한 선택입니다.");
+            }
+        }
     }
 
     public List<OptionPackageDto> getAllPackageByName(String packageName) {

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -31,9 +31,9 @@ public class SelectiveOptionService {
 
         // 각 옵션에 대해 구매 건수를 조회합니다.
         Map<RequiredOption, Long> purchaseCountMap = new HashMap<>();
-        for(RequiredOption eColorOption: requiredOptionList) {
-            Long purchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, eColorOption.getId());
-            purchaseCountMap.put(eColorOption, purchaseCount);
+        for(RequiredOption requiredOption: requiredOptionList) {
+            Long purchaseCount = purchaseHistoryRepository.countByOptionNameAndOptionId(optionName, requiredOption.getId());
+            purchaseCountMap.put(requiredOption, purchaseCount);
         }
 
         // 내림차순으로 정렬합니다.

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -75,11 +75,24 @@ public class SelectiveOptionService {
     }
 
     public List<OptionPackageDto> getAllPackageByName(String packageName) {
-        List<OptionPackageDto> optionPackageDtoList = new ArrayList<>();
-
+        // 해당 카테고리의 모든 옵션 패키지 목록을 받아옵니다.
         List<OptionPackage> packageList = selectiveOptionRepository.findAllPackageByPackageName(packageName);
 
-        for (OptionPackage optionPackage : packageList) {
+        // 각 옵션에 대해 구매 건수를 조회합니다.
+        Map<OptionPackage, Long> purchaseCountMap = new HashMap<>();
+        for(OptionPackage optionPackage: packageList) {
+            Long purchaseCount = purchaseHistoryRepository.countByPackageNameAndOptionId(packageName, optionPackage.getId());
+            purchaseCountMap.put(optionPackage, purchaseCount);
+        }
+
+        // 내림차순으로 정렬합니다.
+        List<OptionPackage> sortedKeys = purchaseCountMap.entrySet().stream()
+                .sorted(Map.Entry.<OptionPackage, Long>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+        List<OptionPackageDto> optionPackageDtoList = new ArrayList<>();
+        for (OptionPackage optionPackage : sortedKeys) {
             List<PackageComponent> packageComponentList = selectiveOptionRepository.findAllComponentByPackageNameAndPackageId(packageName, optionPackage.getId());
             optionPackageDtoList.add(new OptionPackageDto(optionPackage, packageComponentList));
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/feat/order_selective_option_self_page -> dev

### 변경 사항
셀프 모드에서 선택옵션을 구매비율대로 정렬 후 전달하도록 로직을 추가하였습니다.(필수옵션, 부가옵션 모두!)
Close #126 