### PR TITLE
[FE] 가이드 태그 선택 애니메이션, 옵션 id 수정

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -6,6 +6,28 @@
     <link rel="preload" href="/images/main_palisade1.png" as="image" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Oh My Car Set!</title>
+    <style>
+      @font-face {
+        font-family: 'Hyundai Sans Head Medium';
+        font-style: normal;
+        src: url('/fonts/HyundaiSansHeadKROTFMedium.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'Hyundai Sans Head Regular';
+        font-style: normal;
+        src: url('/fonts/HyundaiSansHeadKROTFRegular.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'Hyundai Sans Text Medium';
+        font-style: normal;
+        src: url('/fonts/HyundaiSansTextKROTFMedium.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'Hyundai Sans Text Regular';
+        font-style: normal;
+        src: url('/fonts/HyundaiSansTextKROTFRegular.woff2') format('woff2');
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/Frontend/src/asset/data/guideDescriptionData.json
+++ b/Frontend/src/asset/data/guideDescriptionData.json
@@ -14,7 +14,7 @@
   {
     "page": 3,
     "mainDescription": "이제 마지막이에요.",
-    "mainDescriptionBold": "키워드를 중요한 순서로 3개 선택해주세요.",
+    "mainDescriptionBold": "키워드를 중요한 순서로\n3개 선택해주세요.",
     "subDescription": "나의 관심사와 취향을 반영해 더 자세하게 추천해줄수 있어요."
   }
 ]

--- a/Frontend/src/components/complete/CompleteMain/CompleteMain.style.tsx
+++ b/Frontend/src/components/complete/CompleteMain/CompleteMain.style.tsx
@@ -12,7 +12,7 @@ export const MainContainer = styled.div`
 
 export const GuideText = styled.div`
   width: 294px;
-  height: 96px;
+  /* height: 96px; */
   margin-top: 64px;
   color: #212121;
   text-align: center;
@@ -20,7 +20,7 @@ export const GuideText = styled.div`
   font-size: 34px;
   font-style: normal;
   font-weight: 500;
-  line-height: 44.2px;
+  line-height: 47.6px;
   letter-spacing: -1.36px;
 `;
 

--- a/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.style.tsx
@@ -2,26 +2,98 @@ import { colors } from '@/style/theme';
 import { styled } from 'styled-components';
 
 export const IndicatorContainer = styled.div`
-  display: inline-flex;
-  align-items: flex-start;
-  gap: 16px;
+  position: relative;
+  height: 33px;
+  margin-bottom: 17px;
 `;
 
-export const Indicator = styled.div<{ $selected: boolean }>`
+export const Indicator = styled.div<{ $id: number; $isPrev: boolean; $isNext: boolean }>`
+  position: absolute;
+  left: ${({ $id }) => `${($id - 1) * 49}px`};
   display: flex;
   width: 33px;
   height: 33px;
-  border-radius: 50%;
-  color: ${colors.hyundaiWhite};
+
   align-items: center;
   justify-content: center;
+
+  border-radius: 50%;
+
+  color: ${colors.hyundaiWhite};
   font-family: 'Hyundai Sans Text Regular';
   font-size: 20px;
   font-style: normal;
   font-weight: 400;
   line-height: 28px;
   letter-spacing: -0.8px;
+
   cursor: pointer;
-  ${({ $selected }) =>
-    $selected ? `background-color: ${colors.mainHyundaiBlue}` : ` background-color: ${colors.coolGrey001}`};
+
+  background-color: #dfdfdf;
+
+  ${(props) =>
+    props.$id === 1 &&
+    props.$isNext &&
+    `
+    background-color: ${colors.mainHyundaiBlue};
+  `}
+
+  ${(props) =>
+    props.$isPrev &&
+    `
+    transition: all 0.15s linear;
+    animation: move-right 0.3s linear;
+    animation-fill-mode: forwards;
+  `}
+  ${(props) =>
+    props.$isNext &&
+    props.$id !== 1 &&
+    `
+    transition: all 0.15s linear;
+    animation: move-left 0.3s linear;
+    animation-fill-mode: forwards;
+  `}
+    @keyframes move-right {
+    0% {
+      left: ${({ $id }) => `${($id - 2) * 49}px`};
+      background-color: ${colors.mainHyundaiBlue};
+      z-index: 1;
+    }
+    49% {
+      background-color: ${colors.mainHyundaiBlue};
+      z-index: 1;
+    }
+    50% {
+      left: ${({ $id }) => `${($id - 2) * 49 + 24.5}px`};
+      background-color: #dfdfdf;
+      z-index: 0;
+    }
+    100% {
+      left: ${({ $id }) => `${($id - 2) * 49}px`};
+      background-color: #dfdfdf;
+      z-index: 0;
+    }
+  }
+
+  @keyframes move-left {
+    0% {
+      left: ${({ $id }) => `${($id - 1) * 49}px`};
+      background-color: #dfdfdf;
+      z-index: 0;
+    }
+    49% {
+      background-color: #dfdfdf;
+      z-index: 0;
+    }
+    50% {
+      left: ${({ $id }) => `${($id - 1) * 49 - 24.5}px`};
+      background-color: ${colors.mainHyundaiBlue};
+      z-index: 1;
+    }
+    100% {
+      left: ${({ $id }) => `${($id - 1) * 49}px`};
+      background-color: ${colors.mainHyundaiBlue};
+      z-index: 1;
+    }
+  }
 `;

--- a/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.style.tsx
@@ -4,7 +4,6 @@ import { styled } from 'styled-components';
 export const IndicatorContainer = styled.div`
   position: relative;
   height: 33px;
-  margin-bottom: 17px;
 `;
 
 export const Indicator = styled.div<{ $id: number; $isPrev: boolean; $isNext: boolean }>`

--- a/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.tsx
+++ b/Frontend/src/components/guide-mode/GuideIndicator/GuideIndicator.tsx
@@ -1,9 +1,12 @@
 import * as S from './GuideIndicator.style';
 import guideDescriptionData from '@/asset/data/guideDescriptionData.json';
 import { useGuideModeContext } from '@/contexts/GuideModeProvider';
+import { useEffect, useState } from 'react';
 
 export default function GuideIndicator() {
   const { GuideModeStep, setGuideModeStep } = useGuideModeContext();
+  const [prevId, setPrevId] = useState(1);
+  const [nextId, setNextId] = useState(1);
 
   const handleClick = (page: number) => {
     if (GuideModeStep > page) {
@@ -11,10 +14,21 @@ export default function GuideIndicator() {
     }
   };
 
+  useEffect(() => {
+    setPrevId(GuideModeStep - 1);
+    setNextId(GuideModeStep);
+  }, [GuideModeStep]);
+
   return (
     <S.IndicatorContainer>
       {guideDescriptionData.map((data) => (
-        <S.Indicator key={data.page} $selected={data.page === GuideModeStep} onClick={() => handleClick(data.page)}>
+        <S.Indicator
+          key={data.page}
+          $id={data.page}
+          $isPrev={prevId === data.page}
+          $isNext={nextId === data.page}
+          onClick={() => handleClick(data.page)}
+        >
           {data.page}
         </S.Indicator>
       ))}

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
@@ -3,7 +3,7 @@ import { colors } from '@/style/theme';
 export const MainContainer = styled.div`
   display: flex;
   flex-direction: row;
-  height: 100vh;
+  height: calc(100vh - 110px);
   align-items: center;
   justify-content: space-between;
   width: 1024px;

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
@@ -4,6 +4,7 @@ export const MainContainer = styled.div`
   display: flex;
   flex-direction: row;
   height: calc(100vh - 110px);
+  min-height: 600px;
   align-items: center;
   justify-content: space-between;
   width: 1024px;

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
@@ -83,5 +83,17 @@ export const SubDescription = styled.div`
 export const ButtonContainer = styled.div<{ $hidden: boolean }>`
   margin-top: 24px;
 
-  visibility: ${({ $hidden }) => ($hidden ? `hidden` : `visible`)};
+  ${({ $hidden }) =>
+    $hidden
+      ? `
+      
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    pointer-events: none;
+  `
+      : `
+    opacity: 1;
+    transition: opacity 0.2s ease;
+    pointer-events: all;
+  `}
 `;

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
@@ -11,9 +11,35 @@ export const MainContainer = styled.div`
   margin: 0 auto;
 `;
 
-export const MainLeftContainer = styled.div``;
+export const MainLeftContainer = styled.div`
+  height: 222px;
+  margin: auto 0;
+`;
 
 export const MainRightContainer = styled.div``;
+
+export const DescriptionContainer = styled.div`
+  position: relative;
+  width: 454px;
+`;
+
+export const Description = styled.div<{ $hidden: boolean }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  ${({ $hidden }) =>
+    $hidden
+      ? `
+      
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  `
+      : `
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out;
+  `}
+`;
 
 export const MainDescription = styled.div`
   margin-top: 17px;
@@ -34,6 +60,8 @@ export const MainDescriptionBold = styled.div`
   font-weight: 500;
   line-height: 44.8px;
   letter-spacing: -1.28px;
+
+  white-space: pre-line;
 `;
 
 export const SubDescription = styled.div`

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.style.tsx
@@ -12,15 +12,20 @@ export const MainContainer = styled.div`
 `;
 
 export const MainLeftContainer = styled.div`
-  height: 222px;
+  height: 310px;
   margin: auto 0;
 `;
 
-export const MainRightContainer = styled.div``;
+export const MainRightContainer = styled.div`
+  position: relative;
+  width: 344px;
+  height: 570px;
+`;
 
 export const DescriptionContainer = styled.div`
   position: relative;
   width: 454px;
+  height: 196px;
 `;
 
 export const Description = styled.div<{ $hidden: boolean }>`

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.tsx
@@ -43,7 +43,10 @@ export default function GuideMainTag({ setComplete }: MainProps) {
         </S.MainLeftContainer>
 
         <S.MainRightContainer>
-          {currentIndex === GUIDE_MAX_STEP - 1 ? <GuideMultiTag setShowButton={setShowButton} /> : <GuideSingleTag />}
+          <GuideSingleTag step={1} show={GuideModeStep === 1} />
+          <GuideSingleTag step={2} show={GuideModeStep === 2} />
+          <GuideMultiTag setShowButton={setShowButton} show={currentIndex === GUIDE_MAX_STEP - 1} />
+          {/* {currentIndex === GUIDE_MAX_STEP - 1 ? <GuideMultiTag setShowButton={setShowButton} /> : <GuideSingleTag />} */}
         </S.MainRightContainer>
       </S.MainContainer>
     </>

--- a/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.tsx
+++ b/Frontend/src/components/guide-mode/GuideMainTag/GuideMainTag.tsx
@@ -26,10 +26,15 @@ export default function GuideMainTag({ setComplete }: MainProps) {
       <S.MainContainer>
         <S.MainLeftContainer>
           <GuideIndicator />
-          <S.MainDescription>{guideDescriptionData[currentIndex].mainDescription}</S.MainDescription>
-          <S.MainDescriptionBold>{guideDescriptionData[currentIndex].mainDescriptionBold}</S.MainDescriptionBold>
-          <S.SubDescription>{guideDescriptionData[currentIndex].subDescription}</S.SubDescription>
-
+          <S.DescriptionContainer>
+            {guideDescriptionData.map((data) => (
+              <S.Description key={data.page} $hidden={data.page !== GuideModeStep}>
+                <S.MainDescription>{data.mainDescription}</S.MainDescription>
+                <S.MainDescriptionBold>{data.mainDescriptionBold}</S.MainDescriptionBold>
+                <S.SubDescription>{data.subDescription}</S.SubDescription>
+              </S.Description>
+            ))}
+          </S.DescriptionContainer>
           <S.ButtonContainer $hidden={!showButton || GuideModeStep !== GUIDE_MAX_STEP}>
             <RectButton type="recommended" page="guide" onClick={clickHandler}>
               선택 완료

--- a/Frontend/src/components/guide-mode/GuideModeMain/GuideModeMain.tsx
+++ b/Frontend/src/components/guide-mode/GuideModeMain/GuideModeMain.tsx
@@ -1,9 +1,0 @@
-import GuideMainTag from '@/components/guide-mode/GuideMainTag/GuideMainTag';
-import GuideMainComplete from '../GuideMainComplete/GuideMainComplete';
-import { useState } from 'react';
-
-export default function GuideMain() {
-  const [complete, setComplete] = useState<boolean>(false);
-
-  return <>{complete ? <GuideMainComplete /> : <GuideMainTag setComplete={setComplete} />}</>;
-}

--- a/Frontend/src/components/guide-mode/GuideMultiTag/GuideMultiTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideMultiTag/GuideMultiTag.style.tsx
@@ -2,12 +2,24 @@ import { colors } from '@/style/theme';
 import { headRegular4, bodyMedium2 } from '@/style/typefaces';
 import { styled } from 'styled-components';
 
-export const TagListContainer = styled.div`
+export const TagListContainer = styled.div<{ $show: boolean }>`
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
   max-width: 344px;
   gap: 32px;
+
+  ${({ $show }) =>
+    $show
+      ? `
+    opacity: 1;
+    pointer-events: all;
+    transition: opacity .5s ease-in-out;
+  `
+      : `
+  opacity: 0;
+  pointer-events: none;
+    transition: opacity .5s ease-in-out;`}
 `;
 
 export const TagSubContainer = styled.div``;
@@ -35,6 +47,7 @@ export const TagContainer = styled.div<{ $selected: boolean; $disable: boolean }
   padding-right: 18px;
   border-radius: 6px;
   background-color: ${colors.coolGrey001};
+  border: 2px solid ${colors.coolGrey001};
   color: ${colors.coolGrey003};
 
   cursor: pointer;
@@ -46,8 +59,11 @@ export const TagContainer = styled.div<{ $selected: boolean; $disable: boolean }
     color: #212121;
     background-color: ${colors.hyundaiWhite};
     border: 2px solid ${colors.mainHyundaiBlue};
+    transition: all 0.3s ease;
     `}
   }
+
+  transition: all 0.3s ease;
 
   ${({ $selected }) =>
     $selected &&

--- a/Frontend/src/components/guide-mode/GuideMultiTag/GuideMultiTag.tsx
+++ b/Frontend/src/components/guide-mode/GuideMultiTag/GuideMultiTag.tsx
@@ -6,9 +6,10 @@ import { Dispatch, useEffect, useState } from 'react';
 
 interface MultiProps {
   setShowButton: Dispatch<React.SetStateAction<boolean>>;
+  show: boolean;
 }
 
-export default function GuideMultiTag({ setShowButton }: MultiProps) {
+export default function GuideMultiTag({ setShowButton, show }: MultiProps) {
   const { selectTagList, setSelectTagList } = useSelectTagContext();
   const [selectedTagList, setSelectedTagList] = useState<Set<string>>(new Set());
   const [hoveredTag, setHoveredTag] = useState<string | null>(null);
@@ -41,7 +42,7 @@ export default function GuideMultiTag({ setShowButton }: MultiProps) {
   }, []);
 
   return (
-    <S.TagListContainer>
+    <S.TagListContainer $show={show}>
       {tagCategory.map((category) => (
         <S.TagSubContainer key={category.id}>
           <S.TagSubListTitle>{category.title}</S.TagSubListTitle>

--- a/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.style.tsx
@@ -20,6 +20,7 @@ export const TagContainer = styled.div`
   padding-right: 15px;
   border-radius: 6px;
   background-color: ${colors.coolGrey001};
+  border: 2px solid ${colors.coolGrey001};
   color: ${colors.coolGrey003};
 
   cursor: pointer;
@@ -28,6 +29,7 @@ export const TagContainer = styled.div`
     color: #212121;
     background-color: ${colors.hyundaiWhite};
     border: 2px solid ${colors.mainHyundaiBlue};
+    transition: all 0.3s ease;
   }
 
   &:hover svg {

--- a/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.style.tsx
+++ b/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.style.tsx
@@ -2,11 +2,26 @@ import { colors } from '@/style/theme';
 import { bodyMedium2 } from '@/style/typefaces';
 import { styled } from 'styled-components';
 
-export const TagListContainer = styled.div`
+export const TagListContainer = styled.div<{ $show: boolean; $step: number }>`
+  position: absolute;
+  top: ${({ $step }) => ($step === 1 ? `80px` : `152px`)};
+  left: 0px;
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
+
+  ${({ $show }) =>
+    $show
+      ? `
+    opacity: 1;
+    pointer-events: all;
+    transition: opacity .5s ease-in-out;
+  `
+      : `
+  opacity: 0;
+  pointer-events: none;
+    transition: opacity .5s ease-in-out;`}
 `;
 
 export const TagContainer = styled.div`

--- a/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.tsx
+++ b/Frontend/src/components/guide-mode/GuideSingleTag/GuideSingleTag.tsx
@@ -6,21 +6,25 @@ import { UncheckIcon } from '@/asset/icons';
 import { useSelectTagContext } from '@/contexts/SelectTagProvide';
 import { useState } from 'react';
 
-export default function GuideSingleTag() {
+interface Props {
+  step: number;
+  show: boolean;
+}
+
+export default function GuideSingleTag({ step, show }: Props) {
   const [hovered, setHovered] = useState<number | null>(null);
-  const { GuideModeStep, setGuideModeStep } = useGuideModeContext();
+  const { setGuideModeStep } = useGuideModeContext();
   const { selectTagList, setSelectTagList } = useSelectTagContext();
-  const currentPage = GuideModeStep - 1;
-  const TagList = guideSingleTagData[currentPage].tagList;
+  const TagList = guideSingleTagData[step - 1].tagList;
 
   const handleClick = (tag: string) => {
-    selectTagList[currentPage].value = tag;
-    setGuideModeStep(GuideModeStep + 1);
+    selectTagList[step - 1].value = tag;
+    setGuideModeStep(step + 1);
     setSelectTagList(selectTagList);
   };
 
   return (
-    <S.TagListContainer>
+    <S.TagListContainer $show={show} $step={step}>
       {TagList.map((tag, index) => (
         <S.TagContainer
           key={index}

--- a/Frontend/src/components/self-mode/OptionItem/ShowMoreMulti/ShowMoreMulti.tsx
+++ b/Frontend/src/components/self-mode/OptionItem/ShowMoreMulti/ShowMoreMulti.tsx
@@ -15,7 +15,7 @@ interface ShowMoreProps {
 }
 
 export default function ShowMoreMulti({ contentBoxRef, contentRef, optionId, optionList, showMore }: ShowMoreProps) {
-  const [selectedId, setSelectedId] = useState<number>(1);
+  const [selectedId, setSelectedId] = useState<number>(0);
   const currentPackageDispatch = useCurrentPackageDispatch();
 
   const handleClick = (id: number, event: React.MouseEvent) => {
@@ -53,7 +53,7 @@ export default function ShowMoreMulti({ contentBoxRef, contentRef, optionId, opt
               </S.ShowMoreMainText>
             ))}
           </S.NameContainer>
-          <S.ShowMoreSubText>{optionList[selectedId - 1]?.description}</S.ShowMoreSubText>
+          <S.ShowMoreSubText>{optionList.find((option) => option.id === selectedId)?.description}</S.ShowMoreSubText>
         </S.ShowMoreContainer>
       </S.ShowMoreWrapper>
     </>

--- a/Frontend/src/components/self-mode/OptionItem/ShowMoreMulti/ShowMoreMulti.tsx
+++ b/Frontend/src/components/self-mode/OptionItem/ShowMoreMulti/ShowMoreMulti.tsx
@@ -7,6 +7,7 @@ interface ShowMoreProps {
   contentRef: RefObject<HTMLDivElement>;
   optionId: number;
   optionList: Array<{
+    id: number;
     name: string | null;
     description: string;
   }>;
@@ -17,7 +18,7 @@ export default function ShowMoreMulti({ contentBoxRef, contentRef, optionId, opt
   const [selectedId, setSelectedId] = useState<number>(1);
   const currentPackageDispatch = useCurrentPackageDispatch();
 
-  const handleClick = (idx: number, event: React.MouseEvent) => {
+  const handleClick = (id: number, event: React.MouseEvent) => {
     event.stopPropagation();
     currentPackageDispatch({
       type: 'UPDATE_PACKAGE',
@@ -25,17 +26,17 @@ export default function ShowMoreMulti({ contentBoxRef, contentRef, optionId, opt
     });
     currentPackageDispatch({
       type: 'UPDATE_OPTION',
-      payload: idx,
+      payload: id,
     });
-    setSelectedId(idx);
+    setSelectedId(id);
   };
 
   useEffect(() => {
     currentPackageDispatch({
       type: 'UPDATE_OPTION',
-      payload: 1,
+      payload: optionList[0].id,
     });
-    setSelectedId(1);
+    setSelectedId(optionList[0].id);
   }, [optionList]);
 
   return (
@@ -45,7 +46,7 @@ export default function ShowMoreMulti({ contentBoxRef, contentRef, optionId, opt
           <S.NameContainer>
             {optionList.map((option, idx) => (
               <S.ShowMoreMainText key={option.name}>
-                <S.Name onClick={(e) => handleClick(idx + 1, e)} $selected={selectedId === idx + 1}>
+                <S.Name onClick={(e) => handleClick(option.id, e)} $selected={selectedId === option.id}>
                   {option.name}
                 </S.Name>
                 {idx !== optionList.length - 1 && 'ㆍ'}

--- a/Frontend/src/components/self-mode/SelfModeMain/Estimate/Estimate.tsx
+++ b/Frontend/src/components/self-mode/SelfModeMain/Estimate/Estimate.tsx
@@ -41,14 +41,14 @@ export default function Estimate({ onClick, tempTotal }: EstimateProps) {
         return { stepName: data.stepName, selectName: data.selectedName, price: data.price };
       }),
     },
-    // {
-    //   sectionTitle: '휠',
-    //   sectionTotal: selectOptionState.dataList[5]?.price ?? 0,
-    //   subList: [5].map((idx) => {
-    //     const data = selectOptionState.dataList[idx];
-    //     return { stepName: data.stepName, selectName: data.selectedName, price: data.price };
-    //   }),
-    // },
+    {
+      sectionTitle: '휠',
+      sectionTotal: selectOptionState.dataList[5]?.price ?? 0,
+      subList: [5].map((idx) => {
+        const data = selectOptionState.dataList[idx];
+        return { stepName: data.stepName, selectName: data.selectedName, price: data.price };
+      }),
+    },
     {
       sectionTitle: '선택',
       sectionTotal: selectPackageState.totalPrice,

--- a/Frontend/src/components/self-mode/SelfModeMain/SelfModeMulti/SelfModeMulti.tsx
+++ b/Frontend/src/components/self-mode/SelfModeMain/SelfModeMulti/SelfModeMulti.tsx
@@ -38,6 +38,7 @@ export default function SelfModeMulti() {
   const selectOptionState = useSelectOptionState();
   const [tempTotal, setTempTotal] = useState<number>(selectOptionState.totalPrice);
   const [prevTotal, setPrevTotal] = useState<number>(selectOptionState.totalPrice);
+  const [imgSrc, setImgSrc] = useState('');
 
   const handleFilterOption = (idx: number) => {
     currentPackageDispatch({
@@ -63,8 +64,8 @@ export default function SelfModeMulti() {
         const response = await fetchOptionData(option.key);
         allData.push(response);
       }
-
       setOptionPackage(allData);
+      setImgSrc(allData[0][0].components[0].imgSrc);
     } catch (error) {
       console.error('Error fetching data for all options:', error);
     }
@@ -90,7 +91,7 @@ export default function SelfModeMulti() {
     });
     currentPackageDispatch({
       type: 'UPDATE_OPTION',
-      payload: 1,
+      payload: selectedData.components[0].id,
     });
   };
 
@@ -103,22 +104,29 @@ export default function SelfModeMulti() {
     setTempTotal(selectOptionState.totalPrice + totalPrice);
   }, [totalCount]);
 
+  useEffect(() => {
+    if (optionPackage.length !== 0) {
+      setImgSrc(optionPackage[filterId - 1][0]?.components[0]?.imgSrc);
+    }
+  }, [filterId]);
+
+  useEffect(() => {
+    if (packageId === 0) return;
+    const filterData = optionPackage[filterId - 1];
+    const packageData = filterData?.find((data) => data.id === packageId)?.components;
+    const optionData = packageData?.find((option) => option.id === optionId);
+    if (optionData) {
+      setImgSrc(optionData.imgSrc);
+    } else {
+      if (!packageData) return;
+      setImgSrc(packageData[0].imgSrc);
+    }
+  }, [packageId, optionId]);
+
   return (
     <>
       <S.SelfModeMultiContainer>
-        <S.SelfModeImage>
-          {optionPackage[filterId - 1] && (
-            <img
-              src={`${import.meta.env.VITE_STATIC_API_URL}/${optionPackage[filterId - 1][packageId - 1]?.components[
-                optionId - 1
-              ]?.imgSrc}`}
-              alt={
-                optionPackage[filterId - 1][packageId - 1]?.components[optionId - 1]?.name ??
-                optionPackage[filterId - 1][packageId - 1]?.name
-              }
-            />
-          )}
-        </S.SelfModeImage>
+        <S.SelfModeImage>{imgSrc && <img src={`${import.meta.env.VITE_STATIC_API_URL}/${imgSrc}`} />}</S.SelfModeImage>
         <S.SelfModeOption>
           <S.FilterContainer>
             {optionList.map((option, idx) => (

--- a/Frontend/src/components/self-mode/SelfModeMain/SelfModeSingle/SelfModeSingle.tsx
+++ b/Frontend/src/components/self-mode/SelfModeMain/SelfModeSingle/SelfModeSingle.tsx
@@ -40,7 +40,7 @@ export default function SelfModeSingle() {
   const [stepData, setStepData] = useState<OptionDataT[]>([]);
   const [tempTotal, setTempTotal] = useState<number>(0);
   const [prevTotal, setPrevTotal] = useState<number>(0);
-  const [selectedOption, setSelectedOption] = useState<number>(1);
+  const [selectedOption, setSelectedOption] = useState<OptionDataT>();
   const [showFeedback, setShowFeedback] = useState<number>(0);
 
   const fetchStepData = async () => {
@@ -49,11 +49,13 @@ export default function SelfModeSingle() {
       setStepData(response);
       // 옵션 초기화
       if (selectOptionState.dataList[selfModeStep - 1].selectedId !== 0) {
-        setSelectedOption(selectOptionState.dataList[selfModeStep - 1].selectedId);
+        setSelectedOption(
+          response.find((data: OptionDataT) => data.id === selectOptionState.dataList[selfModeStep - 1].id)
+        );
         setTempTotal(selectOptionState.totalPrice);
         setPrevTotal(selectOptionState.totalPrice);
       } else {
-        setSelectedOption(1);
+        setSelectedOption(response[0]);
         setTempTotal(selectOptionState.totalPrice + response[0].price);
         setPrevTotal(selectOptionState.totalPrice + response[0].price);
       }
@@ -62,8 +64,8 @@ export default function SelfModeSingle() {
     }
   };
 
-  const handleClickOption = (selectedOptionId: number) => {
-    setSelectedOption(selectedOptionId);
+  const handleClickOption = (selectedOption: OptionDataT) => {
+    setSelectedOption(selectedOption);
   };
 
   useEffect(() => {
@@ -74,12 +76,10 @@ export default function SelfModeSingle() {
     setPrevTotal(tempTotal);
     if (selectOptionState.dataList[selfModeStep - 1].selectedId !== 0) {
       setTempTotal(
-        selectOptionState.totalPrice -
-          selectOptionState.dataList[selfModeStep - 1].price +
-          (stepData.find((data) => data.id === selectedOption)?.price || 0)
+        selectOptionState.totalPrice - selectOptionState.dataList[selfModeStep - 1].price + (selectedOption?.price || 0)
       );
     } else {
-      setTempTotal(selectOptionState.totalPrice + (stepData.find((data) => data.id === selectedOption)?.price || 0));
+      setTempTotal(selectOptionState.totalPrice + (selectedOption?.price || 0));
     }
   }, [selectedOption]);
 
@@ -87,12 +87,8 @@ export default function SelfModeSingle() {
     <>
       <S.SelfModeSingleContainer>
         <S.SelfModeImage>
-          {stepData.find((data) => data.id === selectedOption) && (
-            <img
-              src={`${import.meta.env.VITE_STATIC_API_URL}/${stepData.find((data) => data.id === selectedOption)
-                ?.imgSrc}`}
-              alt={stepData.find((data) => data.id === selectedOption)?.name}
-            />
+          {selectedOption && (
+            <img src={`${import.meta.env.VITE_STATIC_API_URL}/${selectedOption?.imgSrc}`} alt={selectedOption?.name} />
           )}
         </S.SelfModeImage>
         <S.SelfModeOption>
@@ -105,14 +101,14 @@ export default function SelfModeSingle() {
               <OptionItem
                 key={data.id}
                 optionData={data}
-                isActive={selectedOption === data.id}
-                onClick={() => handleClickOption(data.id)}
+                isActive={selectedOption?.id === data.id}
+                onClick={() => handleClickOption(data)}
                 showFeedback={showFeedback}
               />
             ))}
           </S.OptionContainer>
           <OptionFooter
-            selectedData={stepData.find((data) => data.id === selectedOption)}
+            selectedData={selectedOption}
             prevTotal={prevTotal}
             tempTotal={tempTotal}
             setShowFeedback={setShowFeedback}

--- a/Frontend/src/components/self-mode/SelfModeMain/SelfModeSingle/SelfModeSingle.tsx
+++ b/Frontend/src/components/self-mode/SelfModeMain/SelfModeSingle/SelfModeSingle.tsx
@@ -71,16 +71,15 @@ export default function SelfModeSingle() {
   }, [selfModeStep]);
 
   useEffect(() => {
-    // console.log(tempTotal, selectOptionState.totalPrice + stepData[selectedOption - 1]?.price);
     setPrevTotal(tempTotal);
     if (selectOptionState.dataList[selfModeStep - 1].selectedId !== 0) {
       setTempTotal(
         selectOptionState.totalPrice -
           selectOptionState.dataList[selfModeStep - 1].price +
-          stepData[selectedOption - 1]?.price
+          (stepData.find((data) => data.id === selectedOption)?.price || 0)
       );
     } else {
-      setTempTotal(selectOptionState.totalPrice + stepData[selectedOption - 1]?.price);
+      setTempTotal(selectOptionState.totalPrice + (stepData.find((data) => data.id === selectedOption)?.price || 0));
     }
   }, [selectedOption]);
 
@@ -88,10 +87,11 @@ export default function SelfModeSingle() {
     <>
       <S.SelfModeSingleContainer>
         <S.SelfModeImage>
-          {stepData[selectedOption - 1] && (
+          {stepData.find((data) => data.id === selectedOption) && (
             <img
-              src={`${import.meta.env.VITE_STATIC_API_URL}/${stepData[selectedOption - 1]?.imgSrc}`}
-              alt={stepData[selectedOption - 1]?.name}
+              src={`${import.meta.env.VITE_STATIC_API_URL}/${stepData.find((data) => data.id === selectedOption)
+                ?.imgSrc}`}
+              alt={stepData.find((data) => data.id === selectedOption)?.name}
             />
           )}
         </S.SelfModeImage>
@@ -112,7 +112,7 @@ export default function SelfModeSingle() {
             ))}
           </S.OptionContainer>
           <OptionFooter
-            selectedData={stepData[selectedOption - 1]}
+            selectedData={stepData.find((data) => data.id === selectedOption)}
             prevTotal={prevTotal}
             tempTotal={tempTotal}
             setShowFeedback={setShowFeedback}

--- a/Frontend/src/contexts/CurrentPackageProvider.tsx
+++ b/Frontend/src/contexts/CurrentPackageProvider.tsx
@@ -13,8 +13,8 @@ type CurrentPackageActionT = {
 
 const initialState: CurrentPackageStateT = {
   filterId: 1,
-  packageId: 1,
-  optionId: 1,
+  packageId: 0,
+  optionId: 0,
 };
 
 type CurrentPackageDispatchT = (action: CurrentPackageActionT) => void;
@@ -24,8 +24,8 @@ const currentPackageReducer = (state: CurrentPackageStateT, action: CurrentPacka
     case 'UPDATE_FILTER':
       return {
         filterId: action.payload,
-        packageId: 1,
-        optionId: 1,
+        packageId: 0,
+        optionId: 0,
       };
     case 'UPDATE_PACKAGE':
       return {

--- a/Frontend/src/pages/GuideModepage/GuideModePage.tsx
+++ b/Frontend/src/pages/GuideModepage/GuideModePage.tsx
@@ -1,13 +1,13 @@
 import Layout from '@/components/layout/Layout';
 import * as S from './GuideModePage.style';
-import GuideModeMain from '../../components/guide-mode/GuideMain/GuideMain';
+import GuideMain from '../../components/guide-mode/GuideMain/GuideMain';
 
 export default function GuideModePage() {
   return (
     <>
       <Layout>
         <S.GuideModeContainer>
-          <GuideModeMain />
+          <GuideMain />
         </S.GuideModeContainer>
       </Layout>
     </>

--- a/Frontend/src/style/global.ts
+++ b/Frontend/src/style/global.ts
@@ -138,27 +138,6 @@ const GlobalStyle = createGlobalStyle`
     * {
         box-sizing: border-box;
     }
-
-    @font-face {
-        font-family: 'Hyundai Sans Head Medium';
-        font-style: normal;
-        src: url('/fonts/HyundaiSansHeadKROTFMedium.woff2') format('woff2'); 
-      }
-      @font-face {
-        font-family: 'Hyundai Sans Head Regular';
-        font-style: normal;
-        src: url('/fonts/HyundaiSansHeadKROTFRegular.woff2') format('woff2'); 
-      }
-      @font-face {
-        font-family: 'Hyundai Sans Text Medium';
-        font-style: normal;
-        src: url('/fonts/HyundaiSansTextKROTFMedium.woff2') format('woff2'); 
-      }  
-      @font-face {
-        font-family: 'Hyundai Sans Text Regular';
-        font-style: normal;
-        src: url('/fonts/HyundaiSansTextKROTFRegular.woff2') format('woff2'); 
-      }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정

### 반영 브랜치
FE/feature/#106 -> fe-dev

### 변경 사항
가이드 태그 선택 애니메이션 추가했습니다
옵션 단일, 다중 선택에서 id로 찾지 않고 인덱스로 접근한 부분들도 수정했습니다
가이드 태그에서 3에서 2로 넘어갈 때 애니메이션 버그가 있는데, 시간을 들여서 이 부분 수정할지 이전으로 돌아가는 액션을 막을지 고민중이에요 ..

- softeerbootcamp-2nd/A3-OhMyCarSet#106
