### PR TITLE
[BE] /selective_option/ 및 /tag/ 엔드포인트 통합 작업(셀프 페이지)

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/RecommendController.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/RecommendController.java
@@ -3,17 +3,29 @@ package com.softeer2nd.ohmycarset.controller;
 import com.softeer2nd.ohmycarset.dto.RecommendDto;
 import com.softeer2nd.ohmycarset.dto.UserInfoDto;
 import com.softeer2nd.ohmycarset.service.SelectiveOptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "유저 프리셋", description = "유저 프리셋 관련 API입니다.")
 public class RecommendController {
     private final SelectiveOptionService selectiveOptionService;
 
     @PostMapping(value = "/recommend")
+    @Cacheable(value = "Preset", key = "{#userInfoDto.age, #userInfoDto.gender, #userInfoDto.tag1, #userInfoDto.tag2, #userInfoDto.tag3}")
+    @Operation(summary = "[가이드페이지]유저 프리셋",
+            description = "유저가 선택한 사항들을 기반으로 프리셋을 만들어 제공합니다.<br>" +
+                    "age[Integer] : 유저의 나이대, ex. 20대면 20, 30대면 30. 반드시 10의 배수로 제공!<br>" +
+                    "gender[Character] : 유저의 성별, 남자면 \"M\", 여자면 \"F\", 선택없음이면 \"N\"(현재 선택없음은 구현 안됐음)<br>" +
+                    "tag1[String] : 유저가 선택한 태그명 1 ex.\"차보호\"<br>" +
+                    "tag2[String] : 유저가 선택한 태그명 2 ex.\"효율\"<br>" +
+                    "tag3[String] : 유저가 선택한 태그명 3 ex.\"디자인 중시\"<br>")
     public RecommendDto getPreset(@RequestBody UserInfoDto userInfoDto) {
         return selectiveOptionService.recommendSelectiveOption(userInfoDto);
     }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/TagController.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/TagController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@Tag(name = "태그", description = "태그 관련 API입니다.")
+@Tag(name = "태그[Depreceated]", description = "태그 관련 API입니다.")
 public class TagController {
 
     private final TagService tagService;
@@ -21,17 +21,17 @@ public class TagController {
         this.tagService = tagService;
     }
 
-    @GetMapping(value = "/tag/required_option/{optionName}")
-    @Operation(summary = "[셀프페이지]필수옵션 구매비율", description = "각 옵션의 구매비율을 제공합니다.\n선택지 : powertrain, wd, body, exterior_color, interior_color, wheel")
-    public List<SelectiveOptionTagDto> getPurchaseTagRequiredOption(@PathVariable String optionName) {
-        return tagService.getPurchaseTagByOptionName(optionName);
-    }
-
-    @GetMapping(value = "/tag/option_package/{packageName}")
-    @Operation(summary = "[셀프페이지]부가옵션 구매비율", description = "각 옵션의 구매비율을 제공합니다.\n선택지 : system, temperature, external_device, internal_device")
-    public List<SelectiveOptionTagDto> getPurchaseTagOptionPackage(@PathVariable String packageName) {
-        return tagService.getPurchaseTagByPackageName(packageName);
-    }
+//    @GetMapping(value = "/tag/required_option/{optionName}")
+//    @Operation(summary = "[셀프페이지]필수옵션 구매비율", description = "각 옵션의 구매비율을 제공합니다.\n선택지 : powertrain, wd, body, exterior_color, interior_color, wheel")
+//    public List<SelectiveOptionTagDto> getPurchaseTagRequiredOption(@PathVariable String optionName) {
+//        return tagService.getPurchaseTagByOptionName(optionName);
+//    }
+//
+//    @GetMapping(value = "/tag/option_package/{packageName}")
+//    @Operation(summary = "[셀프페이지]부가옵션 구매비율", description = "각 옵션의 구매비율을 제공합니다.\n선택지 : system, temperature, external_device, internal_device")
+//    public List<SelectiveOptionTagDto> getPurchaseTagOptionPackage(@PathVariable String packageName) {
+//        return tagService.getPurchaseTagByPackageName(packageName);
+//    }
 
     @PostMapping(value = "/tag/required_option/{optionName}")
     @Cacheable(value = "keywordTagRequiredOption", key = "{#userInfoDto.age, #userInfoDto.gender, #userInfoDto.tag1, #userInfoDto.tag2, #userInfoDto.tag3}")

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/RecommendDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/RecommendDto.java
@@ -5,11 +5,26 @@ import com.softeer2nd.ohmycarset.dto.selectiveOptionDto.RequiredOptionDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.beans.ConstructorProperties;
 import java.util.List;
 
-@RequiredArgsConstructor
 @Getter
 public class RecommendDto {
+
+    @ConstructorProperties({"powertrain", "wd", "body", "exteriorColor", "interiorColor", "wheel", "system", "temperature", "externalDevice", "internalDevice"})
+    public RecommendDto(RequiredOptionDto powertrain, RequiredOptionDto wd, RequiredOptionDto body, RequiredOptionDto exteriorColor, RequiredOptionDto interiorColor, RequiredOptionDto wheel, List<OptionPackageDto> system, List<OptionPackageDto> temperature, List<OptionPackageDto> externalDevice, List<OptionPackageDto> internalDevice) {
+        this.powertrain = powertrain;
+        this.wd = wd;
+        this.body = body;
+        this.exteriorColor = exteriorColor;
+        this.interiorColor = interiorColor;
+        this.wheel = wheel;
+        this.system = system;
+        this.temperature = temperature;
+        this.externalDevice = externalDevice;
+        this.internalDevice = internalDevice;
+    }
+
     private final RequiredOptionDto powertrain;
     private final RequiredOptionDto wd;
     private final RequiredOptionDto body;

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/OptionPackageDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/OptionPackageDto.java
@@ -2,6 +2,7 @@ package com.softeer2nd.ohmycarset.dto.selectiveOptionDto;
 
 import com.softeer2nd.ohmycarset.domain.selective.OptionPackage;
 import com.softeer2nd.ohmycarset.domain.selective.PackageComponent;
+import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.TagDto;
 import lombok.Getter;
 
 import java.beans.ConstructorProperties;
@@ -15,16 +16,36 @@ public class OptionPackageDto {
     private final Integer price;
     private final String iconSrc;
     private final List<PackageComponentDto> components;
+    private final Double purchaseRate;
+    private final List<TagDto> tags;
 
-    @ConstructorProperties({"id", "name", "price", "iconSrc", "components"})
-    public OptionPackageDto(Long id, String name, Integer price, String iconSrc, List<PackageComponentDto> components) {
+    @ConstructorProperties({"id", "name", "price", "iconSrc", "components", "purchaseRate", "tags"})
+    public OptionPackageDto(Long id, String name, Integer price, String iconSrc, List<PackageComponentDto> components, Double purchaseRate, List<TagDto> tagDtoList) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.iconSrc = iconSrc;
         this.components = components;
+        this.purchaseRate = purchaseRate;
+        this.tags = tagDtoList;
     }
 
+    // 셀프모드/가이드모드에서 선택 옵션들을 제공받는 경우 이 생성자를 이용합니다.
+    public OptionPackageDto(OptionPackage optionPackage, List<PackageComponent> componentList, Double purchaseRate, List<TagDto> tagDtoList) {
+        this.id = optionPackage.getId();
+        this.name = optionPackage.getName();
+        this.price = optionPackage.getPrice();
+        this.iconSrc = optionPackage.getIconSrc();
+        List<PackageComponentDto> componentDtoList = new ArrayList<>();
+        for(PackageComponent systemOptionComponent: componentList) {
+            componentDtoList.add(new PackageComponentDto(systemOptionComponent));
+        }
+        this.components = componentDtoList;
+        this.purchaseRate = purchaseRate;
+        this.tags = tagDtoList;
+    }
+
+    // /recommend를 통해 응답을 받는 경우 이 생성자를 이용합니다.
     public OptionPackageDto(OptionPackage optionPackage, List<PackageComponent> componentList) {
         this.id = optionPackage.getId();
         this.name = optionPackage.getName();
@@ -35,5 +56,7 @@ public class OptionPackageDto {
             componentDtoList.add(new PackageComponentDto(systemOptionComponent));
         }
         this.components = componentDtoList;
+        this.purchaseRate = null;
+        this.tags = null;
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/OptionPackageDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/OptionPackageDto.java
@@ -4,6 +4,7 @@ import com.softeer2nd.ohmycarset.domain.selective.OptionPackage;
 import com.softeer2nd.ohmycarset.domain.selective.PackageComponent;
 import lombok.Getter;
 
+import java.beans.ConstructorProperties;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +15,15 @@ public class OptionPackageDto {
     private final Integer price;
     private final String iconSrc;
     private final List<PackageComponentDto> components;
+
+    @ConstructorProperties({"id", "name", "price", "iconSrc", "components"})
+    public OptionPackageDto(Long id, String name, Integer price, String iconSrc, List<PackageComponentDto> components) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.iconSrc = iconSrc;
+        this.components = components;
+    }
 
     public OptionPackageDto(OptionPackage optionPackage, List<PackageComponent> componentList) {
         this.id = optionPackage.getId();

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/PackageComponentDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/PackageComponentDto.java
@@ -4,6 +4,7 @@ import com.softeer2nd.ohmycarset.domain.selective.PackageComponent;
 import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.TagDto;
 import lombok.Getter;
 
+import java.beans.ConstructorProperties;
 import java.util.List;
 
 @Getter
@@ -14,6 +15,16 @@ public class PackageComponentDto {
     private final String imgSrc;
     private final Double purchaseRate;
     private final List<TagDto> tags;
+
+    @ConstructorProperties({"id", "name", "description", "imgSrc", "purchaseRate", "tags"})
+    public PackageComponentDto(Long id, String name, String description, String imgSrc, Double purchaseRate, List<TagDto> tags) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.imgSrc = imgSrc;
+        this.purchaseRate = purchaseRate;
+        this.tags = tags;
+    }
 
     // 셀프모드/가이드모드에서 선택 옵션들을 제공받는 경우 이 생성자를 이용합니다.
     public PackageComponentDto(PackageComponent component, Double purchaseRate, List<TagDto> tagDtoList) {

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/PackageComponentDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/PackageComponentDto.java
@@ -13,27 +13,13 @@ public class PackageComponentDto {
     private final String name;
     private final String description;
     private final String imgSrc;
-    private final Double purchaseRate;
-    private final List<TagDto> tags;
 
     @ConstructorProperties({"id", "name", "description", "imgSrc", "purchaseRate", "tags"})
-    public PackageComponentDto(Long id, String name, String description, String imgSrc, Double purchaseRate, List<TagDto> tags) {
+    public PackageComponentDto(Long id, String name, String description, String imgSrc) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.imgSrc = imgSrc;
-        this.purchaseRate = purchaseRate;
-        this.tags = tags;
-    }
-
-    // 셀프모드/가이드모드에서 선택 옵션들을 제공받는 경우 이 생성자를 이용합니다.
-    public PackageComponentDto(PackageComponent component, Double purchaseRate, List<TagDto> tagDtoList) {
-        this.id = component.getId();
-        this.name = component.getName();
-        this.description = component.getDescription();
-        this.imgSrc = component.getImgSrc();
-        this.purchaseRate = purchaseRate;
-        this.tags = tagDtoList;
     }
 
     // /recommend를 통해 응답을 받는 경우 이 생성자를 이용합니다.
@@ -42,7 +28,5 @@ public class PackageComponentDto {
         this.name = component.getName();
         this.description = component.getDescription();
         this.imgSrc = component.getImgSrc();
-        this.purchaseRate = null;
-        this.tags = null;
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/RequiredOptionDto.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/dto/selectiveOptionDto/RequiredOptionDto.java
@@ -4,6 +4,7 @@ import com.softeer2nd.ohmycarset.domain.selective.RequiredOption;
 import com.softeer2nd.ohmycarset.dto.SelectiveOptionTagDto.TagDto;
 import lombok.Getter;
 
+import java.beans.ConstructorProperties;
 import java.util.List;
 
 @Getter
@@ -19,6 +20,21 @@ public class RequiredOptionDto {
     private final String iconSrc;
     private final Double purchaseRate;
     private final List<TagDto> tags;
+
+    @ConstructorProperties({"id", "name", "mainDescription", "subDescription", "mainFeedback", "subFeedback", "price", "imgSrc", "iconSrc", "purchaseRate", "tags"})
+    public RequiredOptionDto(Long id, String name, String mainDescription, String subDescription, String mainFeedback, String subFeedback, Integer price, String imgSrc, String iconSrc, Double purchaseRate, List<TagDto> tags) {
+        this.id = id;
+        this.name = name;
+        this.mainDescription = mainDescription;
+        this.subDescription = subDescription;
+        this.mainFeedback = mainFeedback;
+        this.subFeedback = subFeedback;
+        this.price = price;
+        this.imgSrc = imgSrc;
+        this.iconSrc = iconSrc;
+        this.purchaseRate = purchaseRate;
+        this.tags = tags;
+    }
 
     // 셀프모드/가이드모드에서 선택 옵션들을 제공받는 경우 이 생성자를 이용합니다.
     public RequiredOptionDto(RequiredOption requiredOption, Double purchaseRate, List<TagDto> tagDtoList) {

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -52,9 +52,12 @@ public class SelectiveOptionService {
             handleExteriorColorOption(sortedKeys);
         }
 
+        // 모든 옵션을 담아 전송합니다.
         List<RequiredOptionDto> requiredOptionDtoList = new ArrayList<>();
+        Long purchaseCountSum = purchaseCountMap.values().stream().mapToLong(Long::longValue).sum(); // 구매비율 계산용
         for (RequiredOption requiredOption : sortedKeys) {
-            requiredOptionDtoList.add(new RequiredOptionDto(requiredOption));
+            Double purchaseRate = (double) purchaseCountMap.get(requiredOption) / purchaseCountSum * 100;
+            requiredOptionDtoList.add(new RequiredOptionDto(requiredOption, purchaseRate, null));
         }
 
         return requiredOptionDtoList;
@@ -97,9 +100,11 @@ public class SelectiveOptionService {
                 .collect(Collectors.toList());
 
         List<OptionPackageDto> optionPackageDtoList = new ArrayList<>();
+        Long purchaseCountSum = purchaseCountMap.values().stream().mapToLong(Long::longValue).sum(); // 구매비율 계산용
         for (OptionPackage optionPackage : sortedKeys) {
             List<PackageComponent> packageComponentList = selectiveOptionRepository.findAllComponentByPackageNameAndPackageId(packageName, optionPackage.getId());
-            optionPackageDtoList.add(new OptionPackageDto(optionPackage, packageComponentList));
+            Double purchaseRate = (double) purchaseCountMap.get(optionPackage) / purchaseCountSum * 100;
+            optionPackageDtoList.add(new OptionPackageDto(optionPackage, packageComponentList, purchaseRate, null));
         }
 
         return optionPackageDtoList;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/feat/selective_option_tag_fusion_self_page -> dev

### 변경 사항
1. 기존 빠졌던 /recommend 엔드포인트를 위한 swagger 문서화 정보 등록 및 Redis Cache 등록을 완료하였습니다.
2. PackageComponentDto에 잘못 붙었던 purchaseRate, tags를 OptionPackageDto로 이동하였습니다.
3. 기존 tag에서 진행됬던 purchaseRate 연산 로직을 selective_option 엔드포인트 쪽으로 옮겨 엔드포인트를 단일화하였습니다. 또, 더 이상 사용되지 않는 /tag/ 엔드포인트들(셀프페이지용)을 비활성화(주석처리) 하였습니다.

Close #134 