### PR TITLE
[FE] 메인 페이지 기본 포함 품목 더보기 버튼 기능 수정

### DIFF
--- a/Frontend/src/components/main/LandingMainDetail/MainDetailLayout/DefaultOption/DefaultOption.tsx
+++ b/Frontend/src/components/main/LandingMainDetail/MainDetailLayout/DefaultOption/DefaultOption.tsx
@@ -34,7 +34,7 @@ const MAX_ITEM_NUM = 5;
 const MAX_ALL_ITEM_NUM = 123;
 const filterCategory = ['전체', '성능', '지능형 안전기술', '안전', '외관', '내장', '시트', '편의', '멀티미디어'];
 
-const ShowMoreButton = ({ itemArrayLength, showLength, onClick }: ShowMoreProps) => {
+function ShowMoreButton({ itemArrayLength, showLength, onClick }: ShowMoreProps) {
   if (itemArrayLength > showLength) {
     return (
       <S.MoreButtonContainer onClick={onClick}>
@@ -43,12 +43,21 @@ const ShowMoreButton = ({ itemArrayLength, showLength, onClick }: ShowMoreProps)
       </S.MoreButtonContainer>
     );
   }
-};
+}
 
 export default function DefaultOption({ isFetched }: Props) {
   const [defaultOption, setDefaultOption] = useState<DefaultOption[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<number>(-1);
   const [showMore, setShowMore] = useState(0);
+  const AllOption: ItemProps[][] = [[], [], [], []];
+
+  defaultOption.map((trim, trimIndex) => {
+    trim.defaultOptionCategoryDtoList.map((categoryDto) =>
+      categoryDto.defaultOptionDetailDtoList.map(
+        (item: ItemProps) => (AllOption[trimIndex] = [...AllOption[trimIndex], item])
+      )
+    );
+  });
 
   const moreEventHandler = () => {
     setShowMore(showMore + 1);
@@ -91,19 +100,14 @@ export default function DefaultOption({ isFetched }: Props) {
           ))}
         </S.ButtonLine>
         <S.OptionContainer>
-          {defaultOption.map((trim) => (
+          {defaultOption.map((trim, trimIndex) => (
             <S.ItemLine key={trim.trimId}>
               {selectedCategory === -1
-                ? trim.defaultOptionCategoryDtoList.map((categoryDto) =>
-                    categoryDto.defaultOptionDetailDtoList.map((item: ItemProps) => (
-                      <S.ItemContainer
-                        key={item.optionId}
-                        $showMore={Math.floor((item.optionId - 1) / MAX_ITEM_NUM) <= showMore}
-                      >
-                        <Item item={item} />
-                      </S.ItemContainer>
-                    ))
-                  )
+                ? AllOption[trimIndex].map((item: ItemProps, itemIndex) => (
+                    <S.ItemContainer key={item.optionId} $showMore={Math.floor(itemIndex / MAX_ITEM_NUM) <= showMore}>
+                      <Item item={item} />
+                    </S.ItemContainer>
+                  ))
                 : trim.defaultOptionCategoryDtoList[selectedCategory].defaultOptionDetailDtoList.map(
                     (item: ItemProps, optionIndex: number) => (
                       <S.ItemContainer

--- a/Frontend/src/components/main/LandingMainDetail/MainDetailLayout/DefaultOption/Item/Item.style.tsx
+++ b/Frontend/src/components/main/LandingMainDetail/MainDetailLayout/DefaultOption/Item/Item.style.tsx
@@ -6,6 +6,7 @@ export const ItemContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+
   gap: 12px;
 `;
 
@@ -21,5 +22,8 @@ export const ItemDescription = styled.div`
   ${bodyMedium2};
   color: ${colors.coolGreyBlack};
   word-break: keep-all;
+  max-width: 80px;
+  max-height: 60px;
+  overflow: auto;
   max-width: 120px;
 `;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 수정

### 반영 브랜치
FE/feature/#146

### 변경 사항
메인 페이지 기본 포함 품목 전체에서 더보기 버튼 클릭시 5개씩 추가 되도록 수정