### PR TITLE
[BE] 캐시 적용 및 캐시 자동 동기화 적용

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -27,13 +27,11 @@ public class CacheUpdateConfig {
 
     // purchaseHistoryRepository
     @CachePut(value = "count")
-    @CacheEvict(value = "count", beforeInvocation = true)
     public Long count() {
         return purchaseHistoryRepository.count();
     }
 
     @CachePut(value = "countByTagId", key = "#tagId")
-    @CacheEvict(value = "countByTagId", key = "#tagId")
     public Long countByTagId(Long tagId) {
         return purchaseHistoryRepository.countByTagId(tagId);
     }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,10 +23,7 @@ public class CacheUpdateConfig {
      * 이 아래로는 주기적 캐시 동기화를 위한 메서드들이 존재합니다.
      */
     private final PurchaseHistoryRepository purchaseHistoryRepository;
-    private final TagRepository tagRepository;
-    private final CacheManager cacheManager;
 
-    // purchaseHistoryRepository
     @CachePut(value = "count")
     public Long count() {
         return purchaseHistoryRepository.count();
@@ -35,4 +33,10 @@ public class CacheUpdateConfig {
     public Long countByTagId(Long tagId) {
         return purchaseHistoryRepository.countByTagId(tagId);
     }
+
+    @CachePut(value = "countByCategoryNameAndOptionId", key = "{#optionName, #optionId}")
+    public Long countByCategoryNameAndOptionId(String optionName, Long optionId) {
+        return purchaseHistoryRepository.countByCategoryNameAndOptionId(optionName, optionId);
+    }
+
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -39,4 +39,8 @@ public class CacheUpdateConfig {
         return purchaseHistoryRepository.countByCategoryNameAndOptionId(optionName, optionId);
     }
 
+    @CachePut(value = "countByCategoryNameAndPackageId", key = "{#categoryName, #packageId}")
+    public Long countByCategoryNameAndPackageId(String categoryName, Long packageId) {
+        return purchaseHistoryRepository.countByCategoryNameAndPackageId(categoryName, packageId);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-@EnableScheduling
 @RequiredArgsConstructor
 public class CacheUpdateConfig {
     /**

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -59,4 +59,9 @@ public class CacheUpdateConfig {
     public List<PurchaseCountDto> countByCategoryNameAndExteriorColorId(String categoryName, Long exteriorColorId) {
         return purchaseHistoryRepository.countByCategoryNameAndExteriorColorId(categoryName, exteriorColorId);
     }
+
+    @CachePut(value = "countByCategoryNameAndOptionIdAndGender", key = "{#categoryName, #optionId, #gender}")
+    public Long countByCategoryNameAndOptionIdAndGender(String categoryName, Long optionId, Character gender) {
+        return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndGender(categoryName, optionId, gender);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -1,6 +1,7 @@
 package com.softeer2nd.ohmycarset.config;
 
 import com.softeer2nd.ohmycarset.domain.Tag;
+import com.softeer2nd.ohmycarset.dto.PurchaseCountDto;
 import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
 import com.softeer2nd.ohmycarset.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +48,10 @@ public class CacheUpdateConfig {
     @CachePut(value = "countByTagIdAndCategoryNameAndOptionId", key = "{#tagId, #categoryName, #optionId}")
     public Long countByTagIdAndCategoryNameAndOptionId(Long tagId, String categoryName, Long optionId) {
         return purchaseHistoryRepository.countByTagIdAndCategoryNameAndOptionId(tagId, categoryName, optionId);
+    }
+
+    @CachePut(value = "countByCategoryNameAndGenderAndAge", key = "{#categoryName, #gender, #age}")
+    public List<PurchaseCountDto> countByCategoryNameAndGenderAndAge(String categoryName, Character gender, Integer age) {
+        return purchaseHistoryRepository.countByCategoryNameAndGenderAndAge(categoryName, gender, age);
     }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -69,4 +69,9 @@ public class CacheUpdateConfig {
     public Long countByCategoryNameAndOptionIdAndAge(String categoryName, Long optionId, Integer age) {
         return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndAge(categoryName, optionId, age);
     }
+
+    @CachePut(value = "countByCategoryNameAndOptionIdAndGenderAndAge", key = "{#categoryName, #optionId, #gender, #age}")
+    public Long countByCategoryNameAndOptionIdAndGenderAndAge(String categoryName, Long optionId, Character gender, Integer age) {
+        return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndGenderAndAge(categoryName, optionId, gender, age);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -64,4 +64,9 @@ public class CacheUpdateConfig {
     public Long countByCategoryNameAndOptionIdAndGender(String categoryName, Long optionId, Character gender) {
         return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndGender(categoryName, optionId, gender);
     }
+
+    @CachePut(value = "countByCategoryNameAndOptionIdAndAge", key = "{#categoryName, #optionId, #age}")
+    public Long countByCategoryNameAndOptionIdAndAge(String categoryName, Long optionId, Integer age) {
+        return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndAge(categoryName, optionId, age);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -54,4 +54,9 @@ public class CacheUpdateConfig {
     public List<PurchaseCountDto> countByCategoryNameAndGenderAndAge(String categoryName, Character gender, Integer age) {
         return purchaseHistoryRepository.countByCategoryNameAndGenderAndAge(categoryName, gender, age);
     }
+
+    @CachePut(value = "countByCategoryNameAndExteriorColorId", key = "{#categoryName, exteriorColorId}")
+    public List<PurchaseCountDto> countByCategoryNameAndExteriorColorId(String categoryName, Long exteriorColorId) {
+        return purchaseHistoryRepository.countByCategoryNameAndExteriorColorId(categoryName, exteriorColorId);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -50,6 +50,11 @@ public class CacheUpdateConfig {
         return purchaseHistoryRepository.countByTagIdAndCategoryNameAndOptionId(tagId, categoryName, optionId);
     }
 
+    @CachePut(value = "countByTagIdAndCategoryNameAndPackageId", key = "{#tagId, #categoryName, #packageId}")
+    public Long countByTagIdAndCategoryNameAndPackageId(Long tagId, String categoryName, Long packageId) {
+        return purchaseHistoryRepository.countByTagIdAndCategoryNameAndPackageId(tagId, categoryName, packageId);
+    }
+
     @CachePut(value = "countByCategoryNameAndGenderAndAge", key = "{#categoryName, #gender, #age}")
     public List<PurchaseCountDto> countByCategoryNameAndGenderAndAge(String categoryName, Character gender, Integer age) {
         return purchaseHistoryRepository.countByCategoryNameAndGenderAndAge(categoryName, gender, age);

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -1,0 +1,40 @@
+package com.softeer2nd.ohmycarset.config;
+
+import com.softeer2nd.ohmycarset.domain.Tag;
+import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
+import com.softeer2nd.ohmycarset.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class CacheUpdateConfig {
+    /**
+     * 이 아래로는 주기적 캐시 동기화를 위한 메서드들이 존재합니다.
+     */
+    private final PurchaseHistoryRepository purchaseHistoryRepository;
+    private final TagRepository tagRepository;
+    private final CacheManager cacheManager;
+
+    // purchaseHistoryRepository
+    @CachePut(value = "count")
+    @CacheEvict(value = "count", beforeInvocation = true)
+    public Long count() {
+        return purchaseHistoryRepository.count();
+    }
+
+    @CachePut(value = "countByTagId", key = "#tagId")
+    @CacheEvict(value = "countByTagId", key = "#tagId")
+    public Long countByTagId(Long tagId) {
+        return purchaseHistoryRepository.countByTagId(tagId);
+    }
+}

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -74,4 +74,9 @@ public class CacheUpdateConfig {
     public Long countByCategoryNameAndOptionIdAndGenderAndAge(String categoryName, Long optionId, Character gender, Integer age) {
         return purchaseHistoryRepository.countByCategoryNameAndOptionIdAndGenderAndAge(categoryName, optionId, gender, age);
     }
+
+    @CachePut(value = "countByGenderAndAge", key = "{#gender, #age}")
+    public Long countByGenderAndAge(Character gender, Integer age) {
+        return purchaseHistoryRepository.countByGenderAndAge(gender, age);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -79,4 +79,14 @@ public class CacheUpdateConfig {
     public Long countByGenderAndAge(Character gender, Integer age) {
         return purchaseHistoryRepository.countByGenderAndAge(gender, age);
     }
+
+    @CachePut(value = "countByGender", key = "#gender")
+    public Long countByGender(Character gender) {
+        return purchaseHistoryRepository.countByGender(gender);
+    }
+
+    @CachePut(value = "countByAge", key = "#age")
+    public Long countByAge(Integer age) {
+        return purchaseHistoryRepository.countByAge(age);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateConfig.java
@@ -43,4 +43,9 @@ public class CacheUpdateConfig {
     public Long countByCategoryNameAndPackageId(String categoryName, Long packageId) {
         return purchaseHistoryRepository.countByCategoryNameAndPackageId(categoryName, packageId);
     }
+
+    @CachePut(value = "countByTagIdAndCategoryNameAndOptionId", key = "{#tagId, #categoryName, #optionId}")
+    public Long countByTagIdAndCategoryNameAndOptionId(Long tagId, String categoryName, Long optionId) {
+        return purchaseHistoryRepository.countByTagIdAndCategoryNameAndOptionId(tagId, categoryName, optionId);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -130,4 +130,19 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByCategoryNameAndOptionIdAndGender() {
+        for(String categoryName: requiredOptionCategoryNameList) {
+            List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByCategoryName(categoryName);
+            for(RequiredOption option: optionList) {
+                for(Character gender: genderList) {
+                    Runnable runnable = () -> {
+                        cacheUpdateConfig.countByCategoryNameAndOptionIdAndGender(categoryName, option.getId(), gender);
+                    };
+                    executorService.submit(runnable);
+                }
+            }
+        }
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -145,4 +145,19 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByCategoryNameAndOptionIdAndAge() {
+        for(String categoryName: requiredOptionCategoryNameList) {
+            List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByCategoryName(categoryName);
+            for(RequiredOption option: optionList) {
+                for(Integer age: ageList) {
+                    Runnable runnable = () -> {
+                        cacheUpdateConfig.countByCategoryNameAndOptionIdAndAge(categoryName, option.getId(), age);
+                    };
+                    executorService.submit(runnable);
+                }
+            }
+        }
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -1,6 +1,7 @@
 package com.softeer2nd.ohmycarset.config;
 
 import com.softeer2nd.ohmycarset.domain.Tag;
+import com.softeer2nd.ohmycarset.domain.selective.OptionPackage;
 import com.softeer2nd.ohmycarset.domain.selective.RequiredOption;
 import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
 import com.softeer2nd.ohmycarset.repository.SelectiveOptionRepository;
@@ -34,7 +35,7 @@ public class CacheUpdateScheduleConfig {
             new ArrayList<>(List.of("system", "temperature", "external_device", "internal_device"));
 
     @Scheduled(fixedRate = refreshPeriod)
-    public void updateCount() {
+    public void count() {
         Runnable runnable = () -> {
             cacheUpdateConfig.count();
         };
@@ -42,7 +43,7 @@ public class CacheUpdateScheduleConfig {
     }
 
     @Scheduled(fixedRate = refreshPeriod)
-    public void updateCountByTagId() {
+    public void countByTagId() {
         // 모든 태그 목록을 불러옵니다.
         List<Long> tagIds = tagRepository.findAll().stream()
                 .map(Tag::getId)
@@ -58,7 +59,7 @@ public class CacheUpdateScheduleConfig {
     }
 
     @Scheduled(fixedRate = refreshPeriod)
-    public void updateCountByCategoryNameAndOptionId() {
+    public void countByCategoryNameAndOptionId() {
         for(String categoryName: requiredOptionCategoryNameList) {
             List<RequiredOption> requiredOptionList = selectiveOptionRepository.findAllOptionByCategoryName(categoryName);
             for(RequiredOption requiredOption: requiredOptionList) {
@@ -69,4 +70,18 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByCategoryNameAndPackageId() {
+        for(String categoryName: optionPackageCategoryNameList) {
+            List<OptionPackage> optionPackageList = selectiveOptionRepository.findAllPackageByCategoryName(categoryName);
+            for(OptionPackage optionPackage: optionPackageList) {
+                Runnable runnable = () -> {
+                    cacheUpdateConfig.countByCategoryNameAndPackageId(categoryName, optionPackage.getId());
+                };
+                executorService.submit(runnable);
+            }
+        }
+    }
+
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -1,0 +1,48 @@
+package com.softeer2nd.ohmycarset.config;
+
+import com.softeer2nd.ohmycarset.domain.Tag;
+import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
+import com.softeer2nd.ohmycarset.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CacheUpdateScheduleConfig {
+
+    private final CacheUpdateConfig cacheUpdateConfig;
+    private final TagRepository tagRepository;
+    private final PurchaseHistoryRepository purchaseHistoryRepository;
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool(300);
+
+    @Scheduled(fixedRate = 10 * 1000)
+    public void updateCount() {
+        Runnable runnable = () -> {
+            cacheUpdateConfig.count();
+        };
+        executorService.submit(runnable);
+    }
+
+    @Scheduled(fixedRate = 10 * 1000)
+    public void updateCountByTagId() {
+        // 모든 태그 목록을 불러옵니다.
+        List<Long> tagIds = tagRepository.findAll().stream()
+                .map(Tag::getId)
+                .collect(Collectors.toList());
+
+        // 각 태그에 대해 캐시 갱신을 진행합니다.
+        for(Long tagId: tagIds) {
+            Runnable runnable = () -> {
+                cacheUpdateConfig.countByTagId(tagId);
+            };
+            executorService.submit(runnable);
+        }
+    }
+}

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -177,4 +177,16 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByGenderAndAge() {
+        for(Character gender: genderList) {
+            for(Integer age: ageList) {
+                Runnable runnable = () -> {
+                    cacheUpdateConfig.countByGenderAndAge(gender, age);
+                };
+                executorService.submit(runnable);
+            }
+        }
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class CacheUpdateScheduleConfig {
 
     private final CacheUpdateConfig cacheUpdateConfig;
-    private final ExecutorService executorService = Executors.newWorkStealingPool(100);
+    private final ExecutorService executorService = Executors.newWorkStealingPool(100); // IO 지연이 많고, CPU 사용률이 낮아 높게 사용
     private final long refreshPeriod = 10 * 1000; // ms 단위
 
     private final TagRepository tagRepository;
@@ -30,9 +30,10 @@ public class CacheUpdateScheduleConfig {
 
     private final List<String> requiredOptionCategoryNameList =
             new ArrayList<>(List.of("powertrain", "wd", "body", "exterior_color", "interior_color", "wheel"));
-
     private final List<String> optionPackageCategoryNameList =
             new ArrayList<>(List.of("system", "temperature", "external_device", "internal_device"));
+    private final List<Character> genderList = new ArrayList<>(List.of('F', 'M', 'N'));
+    private final List<Integer> ageList = new ArrayList<>(List.of(20, 30, 40, 50, 60, 70));
 
     @Scheduled(fixedRate = refreshPeriod)
     public void count() {
@@ -96,6 +97,20 @@ public class CacheUpdateScheduleConfig {
                 for(RequiredOption requiredOption: requiredOptionList) {
                     Runnable runnable = () -> {
                         cacheUpdateConfig.countByTagIdAndCategoryNameAndOptionId(tagId, categoryName, requiredOption.getId());
+                    };
+                    executorService.submit(runnable);
+                }
+            }
+        }
+    }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByCategoryNameAndGenderAndAge() {
+        for(String categoryName: requiredOptionCategoryNameList) {
+            for(Character gender: genderList) {
+                for(Integer age: ageList) {
+                    Runnable runnable = () -> {
+                        cacheUpdateConfig.countByCategoryNameAndGenderAndAge(categoryName, gender, age);
                     };
                     executorService.submit(runnable);
                 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -160,4 +160,21 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByCategoryNameAndOptionIdAndGenderAndAge() {
+        for(String categoryName: requiredOptionCategoryNameList) {
+            List<RequiredOption> optionList = selectiveOptionRepository.findAllOptionByCategoryName(categoryName);
+            for(RequiredOption option: optionList) {
+                for(Character gender: genderList) {
+                    for(Integer age: ageList) {
+                        Runnable runnable = () -> {
+                            cacheUpdateConfig.countByCategoryNameAndOptionIdAndGenderAndAge(categoryName, option.getId(), gender, age);
+                        };
+                        executorService.submit(runnable);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -105,6 +105,25 @@ public class CacheUpdateScheduleConfig {
     }
 
     @Scheduled(fixedRate = refreshPeriod)
+    public void countByTagIdAndCategoryNameAndPackageId() {
+        List<Long> tagIds = tagRepository.findAll().stream()
+                .map(Tag::getId)
+                .collect(Collectors.toList());
+
+        for(Long tagId: tagIds) {
+            for(String categoryName: optionPackageCategoryNameList) {
+                List<OptionPackage> optionPackageList = selectiveOptionRepository.findAllPackageByCategoryName(categoryName);
+                for(OptionPackage optionPackage: optionPackageList) {
+                    Runnable runnable = () -> {
+                        cacheUpdateConfig.countByTagIdAndCategoryNameAndPackageId(tagId, categoryName, optionPackage.getId());
+                    };
+                    executorService.submit(runnable);
+                }
+            }
+        }
+    }
+
+    @Scheduled(fixedRate = refreshPeriod)
     public void countByCategoryNameAndGenderAndAge() {
         for(String categoryName: requiredOptionCategoryNameList) {
             for(Character gender: genderList) {

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -189,4 +189,24 @@ public class CacheUpdateScheduleConfig {
             }
         }
     }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByGender() {
+        for(Character gender: genderList) {
+            Runnable runnable = () -> {
+                cacheUpdateConfig.countByGender(gender);
+            };
+            executorService.submit(runnable);
+        }
+    }
+
+    @Scheduled(fixedRate = refreshPeriod)
+    public void countByAge() {
+        for(Integer age: ageList) {
+            Runnable runnable = () -> {
+                cacheUpdateConfig.countByAge(age);
+            };
+            executorService.submit(runnable);
+        }
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -7,6 +7,7 @@ import com.softeer2nd.ohmycarset.repository.PurchaseHistoryRepository;
 import com.softeer2nd.ohmycarset.repository.SelectiveOptionRepository;
 import com.softeer2nd.ohmycarset.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +18,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 @Component
+@EnableScheduling
 @RequiredArgsConstructor
 public class CacheUpdateScheduleConfig {
 

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -17,12 +17,14 @@ import java.util.stream.Collectors;
 public class CacheUpdateScheduleConfig {
 
     private final CacheUpdateConfig cacheUpdateConfig;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(300);
+    private final long refreshPeriod = 10 * 1000; // ms 단위
+
     private final TagRepository tagRepository;
     private final PurchaseHistoryRepository purchaseHistoryRepository;
 
-    private final ExecutorService executorService = Executors.newFixedThreadPool(300);
 
-    @Scheduled(fixedRate = 10 * 1000)
+    @Scheduled(fixedRate = refreshPeriod)
     public void updateCount() {
         Runnable runnable = () -> {
             cacheUpdateConfig.count();
@@ -30,7 +32,7 @@ public class CacheUpdateScheduleConfig {
         executorService.submit(runnable);
     }
 
-    @Scheduled(fixedRate = 10 * 1000)
+    @Scheduled(fixedRate = refreshPeriod)
     public void updateCountByTagId() {
         // 모든 태그 목록을 불러옵니다.
         List<Long> tagIds = tagRepository.findAll().stream()

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
@@ -1,7 +1,10 @@
 package com.softeer2nd.ohmycarset.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -19,9 +22,10 @@ import java.time.Duration;
 public class RedisConfig {
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        // Jackson은 충분히 크지 않은 수를 Integer로 저장하므로, 형변환 오류가 발생합니다. 이를 명시해줍니다.
+        // Jackson은 일부 자료형을 저장하지 않아 형변환 오류가 발생합니다.(ex. Long)
+        // Jackson이 redis에 자료형 정보들을 저장하도록 유도합니다.
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(DeserializationFeature.USE_LONG_FOR_INTS);
+        objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.EVERYTHING, JsonTypeInfo.As.PROPERTY);
 
         RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory);
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.softeer2nd.ohmycarset.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -17,9 +19,13 @@ import java.time.Duration;
 public class RedisConfig {
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // Jackson은 충분히 크지 않은 수를 Integer로 저장하므로, 형변환 오류가 발생합니다. 이를 명시해줍니다.
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(DeserializationFeature.USE_LONG_FOR_INTS);
+
         RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory);
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
                 .entryTtl(Duration.ofHours(12)); // TTL 12시간으로 지정
         builder.cacheDefaults(configuration);
 

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/RecommendController.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/controller/RecommendController.java
@@ -18,7 +18,6 @@ public class RecommendController {
     private final SelectiveOptionService selectiveOptionService;
 
     @PostMapping(value = "/recommend")
-    @Cacheable(value = "Preset", key = "{#userInfoDto.age, #userInfoDto.gender, #userInfoDto.tag1, #userInfoDto.tag2, #userInfoDto.tag3}")
     @Operation(summary = "[가이드페이지]유저 프리셋",
             description = "유저가 선택한 사항들을 기반으로 프리셋을 만들어 제공합니다.<br>" +
                     "age[Integer] : 유저의 나이대, ex. 20대면 20, 30대면 30. 반드시 10의 배수로 제공!<br>" +

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -159,14 +159,15 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
-    public Long countByCategoryNameAndOptionIdAndAge(String categoryName, Long id, Integer age) {
+    @Cacheable(value = "countByCategoryNameAndOptionIdAndAge", key = "{#categoryName, #optionId, #age}")
+    public Long countByCategoryNameAndOptionIdAndAge(String categoryName, Long optionId, Integer age) {
         String option = categoryName + "_id";
         String query = "SELECT COUNT(*) FROM purchase_history \n" +
                 "WHERE age >= :age AND age <= :age+9 AND " + option + "=:id";
 
         Map<String, Object> params = new HashMap<>();
         params.put("age", age);
-        params.put("id", id);
+        params.put("id", optionId);
 
         return namedTemplate.queryForObject(query, params, Long.class);
     }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -88,6 +88,16 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByTagIdAndCategoryNameAndPackageId", key = "{#tagId, #categoryName, #packageId}")
+    public Long countByTagIdAndCategoryNameAndPackageId(Long tagId, String categoryName, Long packageId) {
+        String table = "purchase_" + categoryName + "_map";
+        String query = "SELECT COUNT(*) FROM purchase_history AS A \n" +
+                "INNER JOIN " + table + " AS M ON A.id=M.purchase_id \n" +
+                "WHERE (A.tag1_id=? OR A.tag2_id=? OR A.tag3_id=?) AND M.option_id=?";
+        return jdbcTemplate.queryForObject(query, Long.class, tagId, tagId, tagId, packageId);
+    }
+
+    @Override
     @Cacheable(value = "countByCategoryNameAndGenderAndAge", key = "{#categoryName, #gender, #age}")
     public List<PurchaseCountDto> countByCategoryNameAndGenderAndAge(String categoryName, Character gender, Integer age) {
         String optionId = categoryName + "_id";
@@ -222,15 +232,6 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
         params.put("age", age);
 
         return namedTemplate.queryForObject(query, params, Long.class);
-    }
-
-    @Override
-    public Long countByTagIdAndCategoryNameAndPackageId(Long tagId, String categoryName, Long packageId) {
-        String table = "purchase_" + categoryName + "_map";
-        String query = "SELECT COUNT(*) FROM purchase_history AS A \n" +
-                "INNER JOIN " + table + " AS M ON A.id=M.purchase_id \n" +
-                "WHERE (A.tag1_id=? OR A.tag2_id=? OR A.tag3_id=?) AND M.option_id=?";
-        return jdbcTemplate.queryForObject(query, Long.class, tagId, tagId, tagId, packageId);
     }
 
     @Override

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -69,6 +69,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByCategoryNameAndPackageId", key = "{#categoryName, #packageId}")
     public Long countByCategoryNameAndPackageId(String categoryName, Long packageId) {
         String table = "purchase_" + categoryName + "_map";
         String sql = "SELECT COUNT(*) FROM " + table + "\n" +

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -88,6 +88,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByCategoryNameAndGenderAndAge", key = "{#categoryName, #gender, #age}")
     public List<PurchaseCountDto> countByCategoryNameAndGenderAndAge(String categoryName, Character gender, Integer age) {
         String optionId = categoryName + "_id";
         String query = "SELECT " + optionId + " AS option_id, count(*) AS count FROM purchase_history \n" +

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -188,6 +188,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByGenderAndAge", key = "{#gender, #age}")
     public Long countByGenderAndAge(Character gender, Integer age) {
         String query = "SELECT count(*) as count FROM purchase_history \n" +
                 "WHERE gender=:gender AND age >= :age AND age <= :age+9";

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.softeer2nd.ohmycarset.repository;
 
 import com.softeer2nd.ohmycarset.domain.PurchaseHistory;
 import com.softeer2nd.ohmycarset.dto.PurchaseCountDto;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -32,6 +33,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "count")
     public Long count() {
         return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM purchase_history", Long.class);
     }
@@ -50,6 +52,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByTagId", key = "#tagId")
     public Long countByTagId(Long tagId) {
         String sql = "SELECT COUNT(*) FROM purchase_history \n" +
                 "WHERE ? IN (tag1_id, tag2_id, tag3_id)";

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -103,6 +103,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByCategoryNameAndExteriorColorId", key = "{#categoryName, #exteriorColorId}")
     public List<PurchaseCountDto> countByCategoryNameAndExteriorColorId(String categoryName, Long exteriorColorId) {
         String optionId = categoryName + "_id";
         String query = "SELECT " + optionId + " AS option_id, count(*) AS count FROM purchase_history \n" +

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -145,14 +145,15 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
-    public Long countByCategoryNameAndOptionIdAndGender(String categoryName, Long id, Character gender) {
+    @Cacheable(value = "countByCategoryNameAndOptionIdAndGender", key = "{#categoryName, #optionId, #gender}")
+    public Long countByCategoryNameAndOptionIdAndGender(String categoryName, Long optionId, Character gender) {
         String option = categoryName + "_id";
         String query = "SELECT count(*) as count FROM purchase_history \n" +
                 "WHERE gender=:gender AND " + option + "=:id";
 
         Map<String, Object> params = new HashMap<>();
         params.put("gender", gender.toString());
-        params.put("id", id);
+        params.put("id", optionId);
 
         return namedTemplate.queryForObject(query, params, Long.class);
     }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -201,6 +201,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByGender", key = "#gender")
     public Long countByGender(Character gender) {
         String query = "SELECT count(*) as count FROM purchase_history \n" +
                 "WHERE gender=:gender";
@@ -212,6 +213,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByAge", key = "#age")
     public Long countByAge(Integer age) {
         String query = "SELECT count(*) as count FROM purchase_history \n" +
                 "WHERE age>=:age AND age<=:age+9";

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -78,8 +78,9 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
-    public Long countByTagIdAndCategoryNameAndOptionId(Long tagId, String optionName, Long optionId) {
-        String column = optionName + "_id";
+    @Cacheable(value = "countByTagIdAndCategoryNameAndOptionId", key = "{#tagId, #categoryName, #optionId}")
+    public Long countByTagIdAndCategoryNameAndOptionId(Long tagId, String categoryName, Long optionId) {
+        String column = categoryName + "_id";
         String sql = "SELECT COUNT(*) FROM purchase_history WHERE\n" +
                 "(tag1_id=? OR tag2_id=? OR tag3_id=?) AND\n" +
                 column + "=?";

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -60,6 +60,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
+    @Cacheable(value = "countByCategoryNameAndOptionId", key = "{#optionName, #optionId}")
     public Long countByCategoryNameAndOptionId(String optionName, Long optionId) {
         String column = optionName + "_id";
         String sql = "SELECT COUNT(*) FROM purchase_history\n" +

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -173,13 +173,14 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     }
 
     @Override
-    public Long countByCategoryNameAndOptionIdAndGenderAndAge(String categoryName, Long id, Character gender, Integer age) {
+    @Cacheable(value = "countByCategoryNameAndOptionIdAndGenderAndAge", key = "{#categoryName, #optionId, #gender, #age}")
+    public Long countByCategoryNameAndOptionIdAndGenderAndAge(String categoryName, Long optionId, Character gender, Integer age) {
         String column = categoryName + "_id";
         String query = "SELECT count(*) as count FROM purchase_history \n" +
                 "WHERE " + column + "=:id AND gender=:gender AND age >= :age AND age <= :age+9";
 
         Map<String, Object> params = new HashMap<>();
-        params.put("id", id);
+        params.put("id", optionId);
         params.put("gender", gender.toString());
         params.put("age", age);
 

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -304,71 +304,22 @@ public class SelectiveOptionService {
 
         // 옵션 선택
         // 외장 색상, 내장 색상의 경우, 연령대 및 성별 별 가장 많이 팔린 옵션으로 설정해줍니다.
-        long startTime = System.nanoTime();
         exteriorColor = getMostPurchasedOptionByCategoryNameAndGenderAndAge("exterior_color", gender, age);
-        long endTime = System.nanoTime();
-        long elapsedTime = endTime - startTime;
-        System.out.println("exterior_color = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
         interiorColor = getMostPurchasedOptionByCategoryNameAndGenderAndAge("interior_color", gender, age);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("interior_color = " + (double) elapsedTime / 1000000);
 
         // 파워트레인, 바디타입, 구동방식은 태그 또한 고려하여 설정합니다.
-        startTime = System.nanoTime();
         powertrain = getMostSelectedOptionByCategoryNameAndGenderAndAgeAndTags("powertrain", gender, age, tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("powertrain = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
         body = getMostSelectedOptionByCategoryNameAndGenderAndAgeAndTags("body", gender, age, tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("body = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
         wd = getMostSelectedOptionByCategoryNameAndGenderAndAgeAndTags("wd", gender, age, tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("wd = " + (double) elapsedTime / 1000000);
 
-        startTime = System.nanoTime();
-        wheel = getWheelOptionByGenderAndAgeAndTagsAndExteriorColor(gender, age, tagIds, exteriorColor.getId());
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("wheel = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
-        system = getAllPackageByCategoryNameAndTags("system", tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("system = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
-        temperature = getAllPackageByCategoryNameAndTags("temperature", tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("temperature = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
-        externalDevice = getAllPackageByCategoryNameAndTags("external_device", tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("external_device = " + (double) elapsedTime / 1000000);
-
-        startTime = System.nanoTime();
-        internalDevice = getAllPackageByCategoryNameAndTags("internal_device", tagIds);
-        endTime = System.nanoTime();
-        elapsedTime = endTime - startTime;
-        System.out.println("internal_device = " + (double) elapsedTime / 1000000);
-
-        System.out.println("=========================");
         // 휠은 별도의 로직이 필요합니다.
+        wheel = getWheelOptionByGenderAndAgeAndTagsAndExteriorColor(gender, age, tagIds, exteriorColor.getId());
 
         // 부가옵션은 겹치는 태그가 하나라도 있으면 모두 담습니다.
+        system = getAllPackageByCategoryNameAndTags("system", tagIds);
+        temperature = getAllPackageByCategoryNameAndTags("temperature", tagIds);
+        externalDevice = getAllPackageByCategoryNameAndTags("external_device", tagIds);
+        internalDevice = getAllPackageByCategoryNameAndTags("internal_device", tagIds);
 
         return new RecommendDto(powertrain, wd, body, exteriorColor, interiorColor, wheel, system, temperature, externalDevice, internalDevice);
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/feat/cache_reload -> dev

### 변경 사항
1. Redis 캐시의 설정이 변경되었습니다.
기존 GenericJackson2JsonRedisSerializer는 Long등의 타입을 저장할 때 클래스 정보를 같이 저장하지 않아, 역직렬화 할 때 Integer 타입으로 파싱하려 하여 문제가 발생했었습니다.
따라서 별도의 ObjectMapper를 정의하여 문제를 해결하였습니다.

2. 컨트롤러 레벨 캐시들을 제거하고, 레포지터리의 일부 메서드에 캐시를 적용하였습니다.
이때, 메모리의 효율적 사용을 위해 tag에 관련된 메서드들은 제외하였습니다.

3. 기존 메서드 내의 디버그용 코드들을 제거하였습니다.


주의사항. 본 패치 적용 이후, 처음 캐시를 등록하는 과정에서 긴 로딩타임이 소요될 수 있습니다.
테스트 상 최초 등록 이후엔 해당 문제가 발생하지 않았습니다.

Close #156 