### PR TITLE
[FE] 가이드 모드 추천 옵션 버그 해결

### DIFF
--- a/Frontend/src/components/guide-mode/GuideIntro/GuideMainTag/GuideMainTag.tsx
+++ b/Frontend/src/components/guide-mode/GuideIntro/GuideMainTag/GuideMainTag.tsx
@@ -31,6 +31,7 @@ export default function GuideMainTag({ setGuideStep }: MainProps) {
   const fetchRecommend = async () => {
     try {
       const response = await fetchPost('recommend', selectTag);
+
       for (let idx = 0; idx < PACKAGE_START_INDEX; idx++) {
         const data = response[optionKeyArr[idx]];
 
@@ -52,7 +53,7 @@ export default function GuideMainTag({ setGuideStep }: MainProps) {
         const key = optionKeyArr[idx];
 
         if (response[key].length === 0) continue;
-        for (let option = 0; option < response[key].length - 1; option++) {
+        for (let option = 0; option < response[key].length; option++) {
           const data = response[key][option];
 
           SelectPackageDispatch({

--- a/Frontend/src/components/self-mode/OptionItem/OptionHeader/OptionHeader.tsx
+++ b/Frontend/src/components/self-mode/OptionItem/OptionHeader/OptionHeader.tsx
@@ -28,9 +28,11 @@ export default function OptionHeader({ isActive, optionData }: Props) {
       const recommendList =
         selfModeStep < 7 ? dataList[selfModeStep - 1].recommendList : packageList[filterId - 1].recommendList;
       if (recommendList === undefined) return;
+
       if (recommendList.some((id) => id === optionData.id)) setIsRecommended(true);
+      else setIsRecommended(false);
     }
-  }, []);
+  }, [optionData]);
 
   return (
     <>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 버그 수정 🐞

### 반영 브랜치
FE/bugFix/#181 -> dev

### 변경 사항
- softeerbootcamp-2nd/A3-OhMyCarSet#181

가이드 모드 추천 옵션 텍스트 바뀜, 태그 안뜨는 오류 해결했습니다~
추가로 가이드 모드에서 받은 유저 프리셋 중 다중 옵션을 하나씩 적게 저장하고 있던 오류도 해결했습니다!
