### PR TITLE
[BE] 가이드모드 성별 [선택안함] 선택시 유사유저/구매비율 구하는 로직 구현

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/RedisConfig.java
@@ -30,7 +30,7 @@ public class RedisConfig {
         RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory);
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
-                .entryTtl(Duration.ofHours(12)); // TTL 12시간으로 지정
+                .entryTtl(Duration.ofHours(24)); // TTL 12시간으로 지정
         builder.cacheDefaults(configuration);
 
         return builder.build();

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepository.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepository.java
@@ -48,4 +48,8 @@ public interface PurchaseHistoryRepository {
     Long countByTagIdAndCategoryNameAndPackageId(Long id, String categoryName, Long id1);
 
     Long countByCategoryNameAndPackageIdAndGenderAndAgeAndTags(String categoryName, Long id, Character gender, Integer age, List<Long> tagIds);
+
+    Long countByCategoryNameAndOptionIdAndAgeAndTags(String categoryName, Long id, Integer age, List<Long> tagIds);
+
+    Long countByAgeAndTags(Integer age, List<Long> tagIds);
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepository.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepository.java
@@ -52,4 +52,6 @@ public interface PurchaseHistoryRepository {
     Long countByCategoryNameAndOptionIdAndAgeAndTags(String categoryName, Long id, Integer age, List<Long> tagIds);
 
     Long countByAgeAndTags(Integer age, List<Long> tagIds);
+
+    Long countByCategoryNameAndPackageIdAndAgeAndTags(String categoryName, Long id, Integer age, List<Long> tagIds);
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -289,4 +289,19 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
 
         return namedTemplate.queryForObject(query, params, Long.class);
     }
+
+    @Override
+    public Long countByCategoryNameAndPackageIdAndAgeAndTags(String categoryName, Long packageId, Integer age, List<Long> tagIds) {
+        String table = "purchase_" + categoryName + "_map";
+        String query = "SELECT count(*) as count FROM purchase_history AS A\n" +
+                "INNER JOIN " + table + " AS M ON A.id=M.purchase_id \n" +
+                "WHERE M.option_id=:packageId AND (A.age >= :age AND A.age <= :age+9 AND A.tag1_id IN (:tagIds) AND A.tag2_id IN (:tagIds) AND A.tag3_id IN (:tagIds)) \n";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("packageId", packageId);
+        params.put("age", age);
+        params.put("tagIds", tagIds);
+
+        return namedTemplate.queryForObject(query, params, Long.class);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -263,4 +263,30 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
 
         return namedTemplate.queryForObject(query, params, Long.class);
     }
+
+    @Override
+    public Long countByCategoryNameAndOptionIdAndAgeAndTags(String categoryName, Long id, Integer age, List<Long> tagIds) {
+        String column = categoryName + "_id";
+        String query = "SELECT count(*) as count FROM purchase_history \n" +
+                "WHERE " + column + "=:id AND (age >= :age AND age <= :age+9 AND tag1_id IN (:tagIds) AND tag2_id IN (:tagIds) AND tag3_id IN (:tagIds)) \n";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", id);
+        params.put("age", age);
+        params.put("tagIds", tagIds);
+
+        return namedTemplate.queryForObject(query, params, Long.class);
+    }
+
+    @Override
+    public Long countByAgeAndTags(Integer age, List<Long> tagIds) {
+        String query = "SELECT count(*) as count FROM purchase_history \n" +
+                "WHERE (age >= :age AND age <= :age+9 AND tag1_id IN (:tagIds) AND tag2_id IN (:tagIds) AND tag3_id IN (:tagIds)) \n";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("age", age);
+        params.put("tagIds", tagIds);
+
+        return namedTemplate.queryForObject(query, params, Long.class);
+    }
 }

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/repository/PurchaseHistoryRepositoryImpl.java
@@ -187,7 +187,7 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     public Long countByCategoryNameAndOptionIdAndAge(String categoryName, Long optionId, Integer age) {
         String option = categoryName + "_id";
         String query = "SELECT COUNT(*) FROM purchase_history \n" +
-                "WHERE age >= :age AND age <= :age+9 AND " + option + "=:id";
+                "WHERE " + option + "=:id AND age >= :age AND age <= :age+9";
 
         Map<String, Object> params = new HashMap<>();
         params.put("age", age);
@@ -199,9 +199,9 @@ public class PurchaseHistoryRepositoryImpl implements PurchaseHistoryRepository 
     @Override
     @Cacheable(value = "countByCategoryNameAndOptionIdAndGenderAndAge", key = "{#categoryName, #optionId, #gender, #age}")
     public Long countByCategoryNameAndOptionIdAndGenderAndAge(String categoryName, Long optionId, Character gender, Integer age) {
-        String column = categoryName + "_id";
+        String option = categoryName + "_id";
         String query = "SELECT count(*) as count FROM purchase_history \n" +
-                "WHERE " + column + "=:id AND gender=:gender AND age >= :age AND age <= :age+9";
+                "WHERE " + option + "=:id AND gender=:gender AND age >= :age AND age <= :age+9";
 
         Map<String, Object> params = new HashMap<>();
         params.put("id", optionId);

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -145,12 +145,20 @@ public class SelectiveOptionService {
         if (categoryName.equals("exterior_color") || categoryName.equals("interior_color")) {
             String genderRepresentation = getGenderRepresentation(gender.toString());
 
-            Double similarPercentage = getSimilarPercentage(categoryName, gender, age, recommendedOption);
-            Double genderRatio = genderRepresentation.equals(NONE) ? 0.0 : getGenderRatio(categoryName, gender, recommendedOption);
+            Double similarPercentage;
+            Double genderRatio;
             Double ageRatio = getAgeRatio(categoryName, age, recommendedOption);
+            List<TagDto> tagDtoList;
 
-            List<TagDto> tagDtoList = Arrays.asList(new TagDto(100L, genderRepresentation, genderRatio), new TagDto(101L, age + "대", ageRatio));
-
+            if (genderRepresentation.equals(NONE)) {
+                similarPercentage = getSimilarPercentage(categoryName, age, recommendedOption);
+                tagDtoList = Arrays.asList(new TagDto(100L, genderRepresentation, 0.0), new TagDto(101L, age + "대", ageRatio));
+            } else {
+                similarPercentage = getSimilarPercentage(categoryName, gender, age, recommendedOption);
+                genderRatio = getGenderRatio(categoryName, gender, recommendedOption);
+                tagDtoList = Arrays.asList(new TagDto(100L, genderRepresentation, genderRatio), new TagDto(101L, age + "대", ageRatio));
+            }
+            
             // 추천 옵션 추가
             response.add(new RequiredOptionDto(recommendedOption, similarPercentage, tagDtoList));
         }
@@ -168,6 +176,7 @@ public class SelectiveOptionService {
 
         return response;
     }
+
 
     public List<OptionPackageDto> getAllPackageByCategory(UserWithPresetDto userInfoDto, String categoryName) {
         List<OptionPackageDto> response = new ArrayList<>();
@@ -262,6 +271,12 @@ public class SelectiveOptionService {
     private Double getSimilarPercentage(String categoryName, Character gender, Integer age, RequiredOption recommendedOption) {
         Long countSimilarUserWithOption = purchaseHistoryRepository.countByCategoryNameAndOptionIdAndGenderAndAge(categoryName, recommendedOption.getId(), gender, age);
         Long countSimilarUser = purchaseHistoryRepository.countByGenderAndAge(gender, age);
+        return (double) countSimilarUserWithOption / countSimilarUser * 100;
+    }
+
+    private Double getSimilarPercentage(String categoryName, Integer age, RequiredOption recommendedOption) {
+        Long countSimilarUserWithOption = purchaseHistoryRepository.countByCategoryNameAndOptionIdAndAge(categoryName, recommendedOption.getId(), age);
+        Long countSimilarUser = purchaseHistoryRepository.countByAge(age);
         return (double) countSimilarUserWithOption / countSimilarUser * 100;
     }
 

--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -184,7 +184,7 @@ public class SelectiveOptionService {
     public List<OptionPackageDto> getAllPackageByCategory(UserWithPresetDto userInfoDto, String categoryName) {
         List<OptionPackageDto> response = new ArrayList<>();
 
-        Character gsender = userInfoDto.getGender();
+        Character gender = userInfoDto.getGender();
         Integer age = userInfoDto.getAge();
         String genderRepresentation = getGenderRepresentation(gender);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/feature/guidemode-no-gender -> dev

### 변경 사항
성별을 [선택안함]으로 선택했을 시의 유사유저/구매비율을 구하는 로직을 추가하였습니다.
