### PR TITLE
[FE] 견적 완료 페이지 선택 옵션 수정 버튼 기능 수정

### DIFF
--- a/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.style.tsx
+++ b/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.style.tsx
@@ -78,6 +78,7 @@ export const ListContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 32px;
+  min-height: 340px;
 `;
 
 export const ItemContainer = styled.div`
@@ -88,9 +89,14 @@ export const ItemContainer = styled.div`
 export const EmptyContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 200px;
   align-items: center;
   justify-content: center;
+
+  height: 240px;
+  margin-bottom: 100px;
+
+  /* border-bottom: 1px solid ${colors.coolGrey003}; */
+
   color: ${colors.coolGrey003};
   font-family: 'Hyundai Sans Text Regular';
   font-size: 20px;

--- a/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.tsx
+++ b/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.tsx
@@ -19,6 +19,11 @@ type DefaultOption = {
   }>;
 };
 
+type PackageAllProps = {
+  id: number;
+  packageData: Array<SelectPackageData>;
+};
+
 interface ItemProps {
   optionId: number;
   optionName: string;
@@ -57,17 +62,19 @@ export default function DetailMultiItem() {
   const [selectedCategory, setSelectedCategory] = useState<number>(-1);
   const [isOption, setIsOption] = useState(true);
   let allOption: ItemProps[] = [];
-  let allSelected: SelectPackageData[] = [];
+  const allSelected: PackageAllProps[] = [];
 
   defaultOption &&
     defaultOption.defaultOptionCategoryDtoList.forEach((categoryDto) => {
       categoryDto.defaultOptionDetailDtoList.forEach((item: ItemProps) => (allOption = [...allOption, item]));
     });
 
-  selectPackageState.subList.forEach((selectedCategoryData: SelectPackageData[]) => {
-    selectedCategoryData.forEach((data: SelectPackageData) => {
-      allSelected = [...allSelected, data];
-    });
+  selectPackageState.subList.forEach((selectedCategoryData: SelectPackageData[], categoryIndex: number) => {
+    const packageObject = {
+      id: categoryIndex,
+      packageData: selectedCategoryData,
+    };
+    allSelected.push(packageObject);
   });
 
   const handleFilterOption = (idx: number) => {
@@ -121,11 +128,13 @@ export default function DetailMultiItem() {
             <S.ListContainer>
               {selectedFilter === -1 ? (
                 allSelected.length ? (
-                  allSelected.map((data: SelectPackageData) => (
-                    <S.ItemContainer key={data.name}>
-                      <DetailItem data={data} index={selectedFilter} />
-                    </S.ItemContainer>
-                  ))
+                  allSelected.map((categoryData: PackageAllProps) =>
+                    categoryData.packageData.map((selectedPackage: SelectPackageData) => (
+                      <S.ItemContainer key={selectedPackage.name}>
+                        <DetailItem data={selectedPackage} index={categoryData.id} />
+                      </S.ItemContainer>
+                    ))
+                  )
                 ) : (
                   <S.EmptyContainer>해당 카테고리에 선택된 옵션이 없습니다.</S.EmptyContainer>
                 )

--- a/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.tsx
+++ b/Frontend/src/components/complete/Detail/DetailMultiItem/DetailMultiItem.tsx
@@ -62,7 +62,7 @@ export default function DetailMultiItem() {
   const [selectedCategory, setSelectedCategory] = useState<number>(-1);
   const [isOption, setIsOption] = useState(true);
   let allOption: ItemProps[] = [];
-  const allSelected: PackageAllProps[] = [];
+  let allSelected: PackageAllProps[] = [];
 
   defaultOption &&
     defaultOption.defaultOptionCategoryDtoList.forEach((categoryDto) => {
@@ -74,7 +74,7 @@ export default function DetailMultiItem() {
       id: categoryIndex,
       packageData: selectedCategoryData,
     };
-    allSelected.push(packageObject);
+    allSelected = [...allSelected, packageObject];
   });
 
   const handleFilterOption = (idx: number) => {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 버그 수정

### 반영 브랜치
FE/fix/#195 -> fe-dev

### 변경 사항
softeerbootcamp-2nd/A3-OhMyCarSet#195
견적 완료 페이지 선택 옵션에서 전체 카테고리 일 때 수정 버튼을 클릭하면 해당하는 페이지에서 데이터가 뜨지 않던 오류 수정
