### PR TITLE
[BE] 가이드모드 옵션상세페이지 추천옵션 외 나머지옵션 누락 해결

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/service/SelectiveOptionService.java
@@ -296,7 +296,7 @@ public class SelectiveOptionService {
         }
         unsortedRemainOptions.sort(Comparator.comparing(RequiredOptionDto::getPurchaseRate, Comparator.reverseOrder()));
 
-
+        response.addAll(unsortedRemainOptions);
         return response;
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/fix/가이드모드-상세옵션누락 -> dev

### 변경 사항
* 추천 옵션을 제외한 나머지 옵션을 응답DTO 에 포함하는 코드 한줄이 누락됐었습니다.
