### PR TITLE
[BE] 쓰레드풀 이용, 캐싱시 DB 죽는 문제 해결

### DIFF
--- a/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
+++ b/backend/ohmycarset/src/main/java/com/softeer2nd/ohmycarset/config/CacheUpdateScheduleConfig.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CacheUpdateScheduleConfig {
 
-    private final ExecutorService executorService = Executors.newWorkStealingPool();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(1);
     private final long refreshPeriod = 24 * 60 * 60 * 1000; // 캐시 동기화 주기
     private final long initDelay = 300 * 1000; // 최초 스케줄링 대기시간(빌드시 테스트 중 스케줄링된 작업들 실행 방지)
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
BE/feat/threadpool -> dev

### 변경 사항
쓰레드풀을 이용해 DB에 캐싱하기 위해 접근하는 작업 스레드를 1개로 동시성을 제한합니다.
